### PR TITLE
Add support for class inheritance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(CXY_MIDDLE_SOURCES
         src/cxy/lang/middle/sema/generics.c
         src/cxy/lang/middle/sema/if.c
         src/cxy/lang/middle/sema/index.c
+        src/cxy/lang/middle/sema/inheritance.c
         src/cxy/lang/middle/sema/interface.c
         src/cxy/lang/middle/sema/match.c
         src/cxy/lang/middle/sema/member.c

--- a/src/cxy/lang/frontend/ast.c
+++ b/src/cxy/lang/frontend/ast.c
@@ -1510,10 +1510,6 @@ AstNode *cloneAstNode(CloneAstConfig *config, const AstNode *node)
     case astPathElem:
         CLONE_MANY(pathElement, args);
         break;
-    case astSubstitution:
-        CLONE_MANY(substitution, variables);
-        CLONE_ONE(substitution, body);
-        break;
     case astPath:
         CLONE_MANY(path, elements);
         break;

--- a/src/cxy/lang/frontend/ast.h
+++ b/src/cxy/lang/frontend/ast.h
@@ -235,11 +235,6 @@ struct AstNode {
         } define;
 
         struct {
-            AstNode *variables;
-            AstNode *body;
-        } substitution;
-
-        struct {
             ImportKind kind;
             struct AstNode *module;
             struct AstNode *exports;

--- a/src/cxy/lang/frontend/ttable.c
+++ b/src/cxy/lang/frontend/ttable.c
@@ -207,11 +207,11 @@ static bool compareTypes(const Type *lhs, const Type *rhs)
     case typEnum:
     case typStruct:
     case typGeneric:
-    case typInfo:
     case typInterface:
     case typClass:
         return (left->name == right->name) && (left->ns == right->ns);
-
+    case typInfo:
+        return compareTypes(left->info.target, right->info.target);
     default:
         unreachable("invalid type");
     }

--- a/src/cxy/lang/frontend/types.h
+++ b/src/cxy/lang/frontend/types.h
@@ -318,6 +318,8 @@ bool isUnionType(const Type *type);
 
 bool isConstType(const Type *type);
 
+bool typeIsBaseOf(const Type *base, const Type *type);
+
 bool hasReferenceMembers(const Type *type);
 
 static inline bool isClassOrStructType(const Type *type)
@@ -363,6 +365,9 @@ static inline const Type *unThisType(const Type *_this)
 {
     return typeIs(_this, This) ? _this->_this.that : _this;
 }
+
+const NamedTypeMember *findOverloadMemberUpInheritanceChain(const Type *type,
+                                                            cstring member);
 
 const NamedTypeMember *findNamedTypeMemberInContainer(
     const TypeMembersContainer *container, cstring member);

--- a/src/cxy/lang/middle/sema/binary.c
+++ b/src/cxy/lang/middle/sema/binary.c
@@ -50,7 +50,8 @@ static void checkBinaryOperatorOverload(AstVisitor *visitor, AstNode *node)
     const Type *left = node->binaryExpr.lhs->type;
     cstring name = getOpOverloadName(node->binaryExpr.op);
     const Type *target = stripPointer(left);
-    const NamedTypeMember *overload = findStructMember(stripAll(target), name);
+    const NamedTypeMember *overload =
+        findOverloadMemberUpInheritanceChain(stripAll(target), name);
 
     if (overload == NULL) {
         logError(ctx->L,

--- a/src/cxy/lang/middle/sema/check.h
+++ b/src/cxy/lang/middle/sema/check.h
@@ -129,6 +129,12 @@ const Type *resolveGenericDecl(AstVisitor *visitor,
                                const AstNode *generic,
                                AstNode *node);
 
+AstNode *inheritanceMakeVTableMember(TypingContext *ctx,
+                                     AstNode *node,
+                                     AstNode *init);
+AstNode *inheritanceBuildVTableType(AstVisitor *visitor, AstNode *node);
+AstNode *inheritanceBuildVTable(TypingContext *ctx, AstNode *node);
+
 const Type *transformToConstructCallExpr(AstVisitor *visitor, AstNode *node);
 AstNode *transformClosureArgument(AstVisitor *visitor, AstNode *node);
 

--- a/src/cxy/lang/middle/sema/function.c
+++ b/src/cxy/lang/middle/sema/function.c
@@ -142,7 +142,7 @@ bool checkMemberFunctions(AstVisitor *visitor,
     AstNode *member = node->structDecl.members;
 
     bool retype = false;
-    for (u64 i = 0; member; member = member->next, i++) {
+    for (u64 i = hasFlag(node, Virtual); member; member = member->next, i++) {
         if (nodeIs(member, FuncDecl)) {
             if (member->funcDecl.this_) {
                 member->funcDecl.this_->type =

--- a/src/cxy/lang/middle/sema/inheritance.c
+++ b/src/cxy/lang/middle/sema/inheritance.c
@@ -1,0 +1,255 @@
+//
+// Created by Carter Mbotho on 2024-03-23.
+//
+
+#include "check.h"
+
+#include "lang/frontend/flag.h"
+#include "lang/frontend/strings.h"
+
+AstNode *vTableMembersFind(TypingContext *ctx,
+                           AstNode *members,
+                           const AstNode *member)
+{
+    AstNode *it = members;
+    while (it) {
+        if (member->_namedNode.name == it->_namedNode.name) {
+            return it;
+        }
+        it = it->next;
+    }
+    return NULL;
+}
+
+static AstNode *makeVTableVariable(TypingContext *ctx,
+                                   AstNode *node,
+                                   AstNode *vTableType,
+                                   AstNode *init)
+{
+    AstNode *vTable = makeVarDecl(
+        ctx->pool,
+        &node->loc,
+        flgConst | flgTopLevelDecl,
+        makeStringConcat(ctx->strings, getDeclarationName(node), "_vTable"),
+        NULL,
+        makeStructExpr(ctx->pool,
+                       &node->loc,
+                       flgConst,
+                       makeResolvedIdentifier(ctx->pool,
+                                              &node->loc,
+                                              vTableType->_namedNode.name,
+                                              0,
+                                              vTableType,
+                                              NULL,
+                                              vTableType->type),
+                       init,
+                       NULL,
+                       vTableType->type),
+        NULL,
+        vTableType->type);
+    addTopLevelDeclaration(ctx, vTable);
+    return vTable;
+}
+
+static AstNode *makeVTableMemberInit(TypingContext *ctx,
+                                     AstNode *node,
+                                     AstNode *vTable)
+{
+    const Type *type_ = makePointerType(ctx->types, vTable->type, flgNone);
+    return makeAddrOffExpr(ctx->pool,
+                           &node->loc,
+                           flgConst,
+                           makeResolvedIdentifier(ctx->pool,
+                                                  &node->loc,
+                                                  vTable->_namedNode.name,
+                                                  0,
+                                                  vTable,
+                                                  NULL,
+                                                  vTable->type),
+                           NULL,
+                           type_);
+}
+
+static AstNode *makeVTableMember(TypingContext *ctx,
+                                 AstNode *node,
+                                 AstNode *vTable)
+{
+    const Type *type_ = makePointerType(ctx->types, vTable->type, flgNone);
+    return makeStructField(ctx->pool,
+                           &node->loc,
+                           S_vtable,
+                           flgConst,
+                           makeTypeReferenceNode(ctx->pool, type_, &node->loc),
+                           makeVTableMemberInit(ctx, node, vTable),
+                           NULL);
+}
+
+static inline AstNode *getVTableMember(AstNode *node)
+{
+    csAssert0(hasFlag(node, Virtual));
+    return node->classDecl.members;
+}
+
+static AstNode *getVTableDefault(AstNode *node)
+{
+    AstNode *member = getVTableMember(node);
+    csAssert0(nodeIs(member, FieldDecl));
+    AstNode *value = member->structField.value;
+    csAssert0(nodeIs(value, AddressOf));
+    value = value->unaryExpr.operand;
+    csAssert0(nodeIs(value, Identifier));
+    value = value->ident.resolvesTo;
+    csAssert0(nodeIs(value, VarDecl));
+    return value->varDecl.init;
+}
+
+static AstNode *getVTableType(AstNode *node)
+{
+    AstNode *def = getVTableDefault(node);
+    csAssert0(nodeIs(def, StructExpr));
+    AstNode *type = def->structExpr.left;
+    csAssert0(nodeIs(type, Identifier));
+    return type->ident.resolvesTo;
+}
+
+static AstNode *makeMemberFunctionRef(TypingContext *ctx,
+                                      AstNode *node,
+                                      AstNode *member)
+{
+    return makePathWithElements(
+        ctx->pool,
+        &member->loc,
+        flgConst,
+        makeResolvedPathElement(
+            ctx->pool,
+            &member->loc,
+            getDeclarationName(node),
+            flgConst,
+            node,
+            makeResolvedPathElement(ctx->pool,
+                                    &member->loc,
+                                    getDeclarationName(member),
+                                    flgConst,
+                                    member,
+                                    NULL,
+                                    member->type),
+            member->type),
+        NULL);
+}
+
+static void inheritanceChainBuildVTableType(TypingContext *ctx,
+                                            AstNodeList *members,
+                                            AstNodeList *init,
+                                            AstNode *node)
+{
+    AstNode *base = node->classDecl.base;
+    if (base != NULL)
+        inheritanceChainBuildVTableType(ctx, members, init, base);
+
+    if (!hasFlag(node, Virtual))
+        return;
+
+    AstNode *member = node->classDecl.members;
+    for (; member; member = member->next) {
+        if (!hasFlag(member, Virtual))
+            continue;
+        AstNode *field = vTableMembersFind(ctx, members->first, member);
+        if (field)
+            continue;
+        insertAstNode(
+            members,
+            makeStructField(
+                ctx->pool,
+                &member->loc,
+                member->_namedNode.name,
+                flgConst,
+                makeTypeReferenceNode(ctx->pool, member->type, &member->loc),
+                NULL,
+                NULL));
+
+        insertAstNode(init,
+                      makeFieldExpr(ctx->pool,
+                                    &member->loc,
+                                    member->_namedNode.name,
+                                    flgConst,
+                                    makeMemberFunctionRef(ctx, node, member),
+                                    NULL));
+    }
+}
+
+AstNode *inheritanceBuildVTableType(AstVisitor *visitor, AstNode *node)
+{
+    TypingContext *ctx = getAstVisitorContext(visitor);
+    AstNodeList members = {NULL}, init = {NULL};
+    csAssert0(hasFlag(node, Virtual));
+    inheritanceChainBuildVTableType(ctx, &members, &init, node);
+    csAssert0(members.first != NULL);
+
+    AstNode *vTableType = makeStructDecl(
+        ctx->pool,
+        &node->loc,
+        flgNone,
+        makeStringConcat(ctx->strings, getDeclarationName(node), "_VTable"),
+        members.first,
+        NULL,
+        NULL);
+
+    node->type = checkType(visitor, vTableType);
+    if (typeIs(node->type, Error))
+        return NULL;
+    addTopLevelDeclaration(ctx, vTableType);
+
+    AstNode *vTable = makeVTableVariable(ctx, node, vTableType, init.first);
+    AstNode *member = makeVTableMember(ctx, node, vTable);
+    member->next = node->classDecl.members;
+    node->classDecl.members = member;
+    return member;
+}
+
+AstNode *inheritanceMakeVTableMember(TypingContext *ctx,
+                                     AstNode *node,
+                                     AstNode *init)
+{
+    AstNode *type = getVTableType(resolvePath(node->classDecl.base));
+    const Type *type_ = makePointerType(ctx->types, type->type, flgNone);
+    AstNode *member =
+        makeStructField(ctx->pool,
+                        &node->loc,
+                        S_vtable,
+                        flgConst,
+                        makeTypeReferenceNode(ctx->pool, type_, &node->loc),
+                        init,
+                        NULL);
+    member->next = node->classDecl.members;
+    node->classDecl.members = member;
+    return member;
+}
+
+AstNode *inheritanceBuildVTable(TypingContext *ctx, AstNode *node)
+{
+    AstNode *base = resolvePath(node->classDecl.base);
+    AstNode *def = getVTableDefault(base), *type = getVTableType(base);
+
+    AstNodeList value = {NULL};
+    AstNode *member = def->structExpr.fields;
+    for (; member; member = member->next) {
+        AstNode *func =
+            findMemberDeclInType(node->type, member->_namedNode.name);
+        if (func == NULL) {
+            insertAstNode(&value, deepCloneAstNode(ctx->pool, member));
+        }
+        else {
+            // Change the function we resolve to
+            insertAstNode(&value,
+                          makeFieldExpr(ctx->pool,
+                                        &member->loc,
+                                        member->_namedNode.name,
+                                        member->flags,
+                                        makeMemberFunctionRef(ctx, node, func),
+                                        NULL));
+        }
+    }
+
+    AstNode *vTable = makeVTableVariable(ctx, node, type, value.first);
+    return makeVTableMemberInit(ctx, node, vTable);
+}

--- a/src/cxy/lang/middle/sema/member.c
+++ b/src/cxy/lang/middle/sema/member.c
@@ -100,19 +100,17 @@ void checkMemberExpr(AstVisitor *visitor, AstNode *node)
             node->type = ERROR_TYPE(ctx);
         }
         if (member->ident.super) {
-            node->memberExpr.target = makeMemberExpr(
-                ctx->pool,
-                &target->loc,
-                target->flags,
-                target,
-                makeIdentifier(ctx->pool,
-                               &target->loc,
-                               S_super,
-                               member->ident.super - 1,
-                               NULL,
-                               member->ident.resolvesTo->parentScope->type),
-                NULL,
-                member->ident.resolvesTo->parentScope->type);
+            node->memberExpr.target =
+                makeCastExpr(ctx->pool,
+                             &target->loc,
+                             target->flags,
+                             target,
+                             makeTypeReferenceNode(
+                                 ctx->pool,
+                                 member->ident.resolvesTo->parentScope->type,
+                                 &target->loc),
+                             NULL,
+                             member->ident.resolvesTo->parentScope->type);
             member->ident.super--;
         }
     }

--- a/src/cxy/runtime/builtins.cxy
+++ b/src/cxy/runtime/builtins.cxy
@@ -7,6 +7,7 @@ pub extern func malloc(s: u64): &void
 pub extern func realloc(ptr: &void, s: u64): &void
 pub extern func free(ptr: &void): void
 pub extern func abort(): void;
+pub extern func printf(s: string, ...args: auto): i32
 
 pub extern func write(fd: i32, buf: &const void, len: u64) : i64
 
@@ -171,128 +172,88 @@ struct CString {
 
 #const CXY_STRING_BUILDER_DEFAULT_CAPACITY = 32:u64
 
-class String {
-    - _capacity: u64 = 0;
-    - _size: u64 = 0;
-    - _data: &char = null;
-
-    - func grow(growSize: u64) {
-        const newSize = _size + growSize;
-        if (this._data == null) {
-            this._data = <&char> __cxy_alloc(growSize + 1)
-            this._capacity = growSize
-        }
-        else if (this._capacity < newSize) {
-            while (this._capacity < newSize) {
-                this._capacity <<= 1
-            }
-            this._data = <&char> __cxy_realloc(this._data !: &void, this._capacity+1)
-        }
-    }
-
-    @inline
-    func `init`() {}
-
-    @inline
-    func `init`(str: string) {
-        appendString(str)
-    }
-
-    @inline
-    func `deinit`() => {
-        if (_data != null) {
-            __cxy_free(this._data)
-            this._data = null
-        }
-    }
-
-    func appendString(str: &const char, size: u64) {
-        if (size) {
-            grow(size)
-            var p = this._data + this._size;
-            memmove(p, str, size)
-            this._size += size
-            this._data.[this._size] = <char>'\0'
-        }
-    }
+class OutputStream {
+    virtual func append(str: &const char, size: u64): void
 
     @inline
     func appendString(s: string) : void {
-        appendString(s: &const char, strlen(s))
+        append(s: &const char, strlen(s))
     }
 
     @inline
     func appendString(s: CString) : void {
-        appendString(s.s: &const char, s.size())
+        append(s.s: &const char, s.size())
     }
 
     func appendSignedInt(num: i64) {
         var buf: [char, 64];
         const len = sprintf(buf, "%lld", num);
-        appendString(buf, len)
+        append(buf, len)
     }
 
     func appendUnSignedInt(num: u64) {
         var buf: [char, 32];
         const len = sprintf(buf, "%llu", num);
-        appendString(buf, len)
+        append(buf, len)
     }
 
     func appendFloat(num: f64) {
         var data: [char, 32];
         const len = sprintf(data, "%g", num);
-        appendString(data, len)
+        append(data, len)
     }
 
     func appendChar(ch: wchar) {
+        var data: [char, 5];
+        var size: u64 = 0;
         if (ch < 0x80) {
-            grow(1);
-            this._data.[this._size++] = <char> ch
+            data.[0] = <char> ch
+            size = 1
         }
         else if (ch < 0x800) {
-            grow(2);
-            this._data.[this._size++] = <char> (0xC0 | (ch >> 6))
-            this._data.[this._size++] = <char> (0x80 | (ch & 0x3f))
+            data.[0] = <char> (0xC0 | (ch >> 6))
+            data.[1] = <char> (0x80 | (ch & 0x3f))
+            size = 2;
         }
         else if (ch < 0x10000) {
-            grow(3);
-            this._data.[this._size++] = <char> (0xE0 | (ch >> 12))
-            this._data.[this._size++] = <char> (0x80 | ((ch >> 6) & 0x3f))
-            this._data.[this._size++] = <char> (0x80 | (ch & 0x3f))
+            data.[0] = <char> (0xE0 | (ch >> 12))
+            data.[1] = <char> (0x80 | ((ch >> 6) & 0x3f))
+            data.[2] = <char> (0x80 | (ch & 0x3f))
+            size = 3
         }
         else if (ch < 0x200000) {
-            grow(4);
-            this._data.[this._size++] = <char> (0xF0 | (ch >> 16))
-            this._data.[this._size++] = <char> (0x80 | ((ch >> 12) & 0x3f))
-            this._data.[this._size++] = <char> (0x80 | ((ch >> 6) & 0x3f))
-            this._data.[this._size++] = <char> (0x80 | (ch & 0x3f))
+            data.[0] = <char> (0xF0 | (ch >> 16))
+            data.[1] = <char> (0x80 | ((ch >> 12) & 0x3f))
+            data.[2] = <char> (0x80 | ((ch >> 6) & 0x3f))
+            data.[3] = <char> (0x80 | (ch & 0x3f))
+            size = 4
         }
         else {
             // TODO raise OutOfRangeException()
         }
-        this._data.[this._size] = <char>'\0'
+        append(data, size)
     }
 
 
     @inline
     func appendBool(val: bool) {
         if (val)
-            appendString("true": &const char, 4)
+            append("true": &const char, 4)
         else
-            appendString("false": &const char, 5)
+            append("false": &const char, 5)
     }
 
     func appendPointer[T](ptr: &const T) {
         var data: [char, 32];
         const len = sprintf(data, "%p", ptr: &const void);
-        appendString(data, len)
+        append(data, len)
     }
 
     @inline
-    func `<<`[U](val: const U) : String {
+    func `<<`[U](val: const U) : OutputStream {
         #if (U.isString)
             #if (U.isClass)
-                appendString(val._data:  &const char, val.size())
+                append(val._data:  &const char, val.size())
             else
                 appendString(val)
         else #if (U.isInteger)
@@ -356,13 +317,59 @@ class String {
         }
         return this
     }
+}
+
+class String : OutputStream {
+    - _capacity: u64 = 0;
+    - _size: u64 = 0;
+    - _data: &char = null;
+
+    - func grow(growSize: u64) {
+        const newSize = _size + growSize;
+        if (this._data == null) {
+            this._data = <&char> __cxy_alloc(growSize + 1)
+            this._capacity = growSize
+        }
+        else if (this._capacity < newSize) {
+            while (this._capacity < newSize) {
+                this._capacity <<= 1
+            }
+            this._data = <&char> __cxy_realloc(this._data !: &void, this._capacity+1)
+        }
+    }
+
+    @inline
+    func `init`() {}
+
+    @inline
+    func `init`(str: string) {
+        super.appendString(str)
+    }
+
+    @inline
+    func `deinit`() => {
+        if (_data != null) {
+            __cxy_free(this._data)
+            this._data = null
+        }
+    }
+
+    func append(str: &const char, size: u64) {
+        if (size) {
+            grow(size)
+            var p = this._data + this._size;
+            memmove(p, str, size)
+            this._size += size
+            this._data.[this._size] = <char>'\0'
+        }
+    }
 
     @inline
     func `+`[U](other: const U) => this << other
 
     @inline
-    func `str`(sb: String) {
-        sb.appendString(_data, _size)
+    func `str`(sb: OutputStream) {
+        sb.append(_data, _size)
     }
 
     @inline
@@ -452,6 +459,19 @@ class String {
     @inline const func data() => _data
 }
 
+class OutputFileStream : OutputStream {
+    - fd: i32
+    func `init`(fd: i32 = 0) {
+        this.fd = fd
+    }
+
+    func append(str: &const char, size: u64) {
+        if (size) {
+           write(fd, str, size)
+        }
+    }
+}
+
 pub struct Slice[T] {
     - data: &T
     - len: u64
@@ -496,7 +516,7 @@ pub struct Slice[T] {
         return code
     }
 
-    const func `str`(sb: String) {
+    const func `str`(sb: OutputStream) {
         sb.appendChar('[')
         for (const i: 0..len) {
             if (i != 0)
@@ -524,6 +544,9 @@ pub func deallocate[T](ptr: T) {
     __cxy_free(ptr: &void)
 }
 
+pub var stdout: OutputStream = null;
+pub var stderr: OutputStream = null;
+
 @inline
 pub func print[T](data: const T) {
     #if (T.isString) {
@@ -540,12 +563,7 @@ pub func print[T](data: const T) {
 }
 
 pub func println(...args: auto) {
-    var s = String();
     #for (const x: args) {
-        s << #{x}
+        stdout << #{x}
     }
-    write(0, s.data(), s.size())
-    write(0, "\n", 1)
-
-    deallocate(s)
 }

--- a/tests/hello.cxy
+++ b/tests/hello.cxy
@@ -1,19 +1,9 @@
+var ofs: OutputFileStream;
 
-class OutputStream {
-    virtual func hello() { }
-    virtual func write(data: &const void, len: u64) : i64
-    // the rest goes here
-}
-
-class StringStream : OutputStream {
-    func `init`(){ }
-
-    @override
-    const func write(data: &const void, len: u64) {
-        println("Hello World")
-    }
-}
-
-pub func main(argc: i32, argv: &string) {
-    var os = StringStream();
+pub func main() {
+    stdout = OutputFileStream(1)
+    stdout << "Hello "
+           << "World "
+           << true
+   println("We used println to print this")
 }

--- a/tests/lang/closure.expected.dump
+++ b/tests/lang/closure.expected.dump
@@ -77,9 +77,9 @@ pub func hash13(val: string, init: Hash = 16777619): Hash {
 
 
 
-pub func String_op__lshift14(this: String, val: string): String {
+pub func OutputStream_op__lshift14(this: OutputStream, val: string): OutputStream {
   
-  String_appendString(this, ({
+  OutputStream_appendString(this, ({
     var s15 = CString{s = null}
     CString_op__init(&s15, val)
     s15
@@ -99,17 +99,17 @@ pub func Slice6_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice6_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 468, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
   this.data.[index] = data
 }
 
 pub func Slice6_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 474, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
   return this.data.[index]
 }
 
 pub func Slice6_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 480, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
   return this.data.[index]
 }
 
@@ -132,19 +132,19 @@ pub func Slice6_op__hash(this: const &Slice[string]): u32 {
 
 
 
-pub func Slice6_op__str(this: const &Slice[string], sb: String) {
-  String_appendChar(sb, '[')
+pub func Slice6_op__str(this: const &Slice[string], sb: OutputStream) {
+  OutputStream_appendChar(sb, '[')
   {
     const i = 0
     while (i != this.len)
     {
       if (i != 0) {
-        String_appendString(sb, ", ")
+        OutputStream_appendString(sb, ", ")
       }
-      String_op__lshift14(sb, this.data.[i])
+      OutputStream_op__lshift14(sb, this.data.[i])
     }
   }
-  String_appendChar(sb, ']')
+  OutputStream_appendChar(sb, ']')
 }
 
 struct __Closure16{ }
@@ -154,9 +154,11 @@ pub func __Closure16_op__call(this: &__Closure16): i8 {
 }
 
 
+
 pub func allocate18(len: u32 = 0): String {
   var obj = (__cxy_alloc(__bc(0, #String)) : class String)
   {
+    obj.vtable = &String_vTable
     obj._capacity = 0
     obj._size = 0
     obj._data = null
@@ -167,21 +169,21 @@ pub func allocate18(len: u32 = 0): String {
 struct __Closure19{ }
 
 
-pub func __Closure19_op__call(this: &__Closure19, name: string): String {
+pub func __Closure19_op__call(this: &__Closure19, name: string): OutputStream {
   return ({
     var sb = ({
       var s17 = allocate18(<u32>0)
       String_op__init(s17)
       s17
     })
-    String_op__lshift14(String_op__lshift14(sb, "Hello "), name)
+    OutputStream_op__lshift14(OutputStream_op__lshift14(<OutputStream>sb, "Hello "), name)
   })
 }
 
 
-pub func String_op__lshift21(this: String, val: i8): String {
+pub func OutputStream_op__lshift21(this: OutputStream, val: i8): OutputStream {
   
-  String_appendSignedInt(this, <i64>val)
+  OutputStream_appendSignedInt(this, <i64>val)
   return this
 }
 
@@ -190,14 +192,14 @@ struct __Closure22 {
   - x: i8
 }
 
-pub func __Closure22_op__call(this: &__Closure22): String {
+pub func __Closure22_op__call(this: &__Closure22): OutputStream {
   return ({
     var sb = ({
       var s20 = allocate18(<u32>0)
       String_op__init(s20)
       s20
     })
-    String_op__lshift21(String_op__lshift14(String_op__lshift14(sb, this.b), " -> "), this.x)
+    OutputStream_op__lshift21(OutputStream_op__lshift14(OutputStream_op__lshift14(<OutputStream>sb, this.b), " -> "), this.x)
   })
 }
 
@@ -206,14 +208,14 @@ struct __Closure24 {
   - x: i8
 }
 
-pub func __Closure24_op__call(this: &__Closure24): String {
+pub func __Closure24_op__call(this: &__Closure24): OutputStream {
   return ({
     var sb = ({
       var s23 = allocate18(<u32>0)
       String_op__init(s23)
       s23
     })
-    String_op__lshift21(String_op__lshift14(String_op__lshift14(sb, this.b), " -> "), this.x)
+    OutputStream_op__lshift21(OutputStream_op__lshift14(OutputStream_op__lshift14(<OutputStream>sb, this.b), " -> "), this.x)
   })
 }
 

--- a/tests/lang/literals.expected.dump
+++ b/tests/lang/literals.expected.dump
@@ -65,9 +65,9 @@ pub func hash13(val: string, init: Hash = 16777619): Hash {
 
 
 
-pub func String_op__lshift14(this: String, val: string): String {
+pub func OutputStream_op__lshift14(this: OutputStream, val: string): OutputStream {
   
-  String_appendString(this, ({
+  OutputStream_appendString(this, ({
     var s15 = CString{s = null}
     CString_op__init(&s15, val)
     s15
@@ -87,17 +87,17 @@ pub func Slice6_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice6_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 468, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
   this.data.[index] = data
 }
 
 pub func Slice6_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 474, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
   return this.data.[index]
 }
 
 pub func Slice6_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 480, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
   return this.data.[index]
 }
 
@@ -120,19 +120,19 @@ pub func Slice6_op__hash(this: const &Slice[string]): u32 {
 
 
 
-pub func Slice6_op__str(this: const &Slice[string], sb: String) {
-  String_appendChar(sb, '[')
+pub func Slice6_op__str(this: const &Slice[string], sb: OutputStream) {
+  OutputStream_appendChar(sb, '[')
   {
     const i = 0
     while (i != this.len)
     {
       if (i != 0) {
-        String_appendString(sb, ", ")
+        OutputStream_appendString(sb, ", ")
       }
-      String_op__lshift14(sb, this.data.[i])
+      OutputStream_op__lshift14(sb, this.data.[i])
     }
   }
-  String_appendChar(sb, ']')
+  OutputStream_appendChar(sb, ']')
 }
 
 func main(args: Slice6) {

--- a/tests/lang/tuples.expected.dump
+++ b/tests/lang/tuples.expected.dump
@@ -73,9 +73,9 @@ pub func hash13(val: string, init: Hash = 16777619): Hash {
 
 
 
-pub func String_op__lshift14(this: String, val: string): String {
+pub func OutputStream_op__lshift14(this: OutputStream, val: string): OutputStream {
   
-  String_appendString(this, ({
+  OutputStream_appendString(this, ({
     var s15 = CString{s = null}
     CString_op__init(&s15, val)
     s15
@@ -95,17 +95,17 @@ pub func Slice6_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice6_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 468, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
   this.data.[index] = data
 }
 
 pub func Slice6_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 474, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
   return this.data.[index]
 }
 
 pub func Slice6_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 480, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
   return this.data.[index]
 }
 
@@ -128,19 +128,19 @@ pub func Slice6_op__hash(this: const &Slice[string]): u32 {
 
 
 
-pub func Slice6_op__str(this: const &Slice[string], sb: String) {
-  String_appendChar(sb, '[')
+pub func Slice6_op__str(this: const &Slice[string], sb: OutputStream) {
+  OutputStream_appendChar(sb, '[')
   {
     const i = 0
     while (i != this.len)
     {
       if (i != 0) {
-        String_appendString(sb, ", ")
+        OutputStream_appendString(sb, ", ")
       }
-      String_op__lshift14(sb, this.data.[i])
+      OutputStream_op__lshift14(sb, this.data.[i])
     }
   }
-  String_appendChar(sb, ']')
+  OutputStream_appendChar(sb, ']')
 }
 
 func main(args: Slice6) {

--- a/tests/lang/varargs.expected.dump
+++ b/tests/lang/varargs.expected.dump
@@ -65,9 +65,9 @@ pub func hash13(val: string, init: Hash = 16777619): Hash {
 
 
 
-pub func String_op__lshift14(this: String, val: string): String {
+pub func OutputStream_op__lshift14(this: OutputStream, val: string): OutputStream {
   
-  String_appendString(this, ({
+  OutputStream_appendString(this, ({
     var s15 = CString{s = null}
     CString_op__init(&s15, val)
     s15
@@ -87,17 +87,17 @@ pub func Slice6_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice6_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 468, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
   this.data.[index] = data
 }
 
 pub func Slice6_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 474, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
   return this.data.[index]
 }
 
 pub func Slice6_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 480, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
   return this.data.[index]
 }
 
@@ -120,19 +120,19 @@ pub func Slice6_op__hash(this: const &Slice[string]): u32 {
 
 
 
-pub func Slice6_op__str(this: const &Slice[string], sb: String) {
-  String_appendChar(sb, '[')
+pub func Slice6_op__str(this: const &Slice[string], sb: OutputStream) {
+  OutputStream_appendChar(sb, '[')
   {
     const i = 0
     while (i != this.len)
     {
       if (i != 0) {
-        String_appendString(sb, ", ")
+        OutputStream_appendString(sb, ", ")
       }
-      String_op__lshift14(sb, this.data.[i])
+      OutputStream_op__lshift14(sb, this.data.[i])
     }
   }
-  String_appendChar(sb, ']')
+  OutputStream_appendChar(sb, ']')
 }
 
 func varargs16(...args: (i8, string, wchar, f64)) { }

--- a/tests/lang/variables.expected.dump
+++ b/tests/lang/variables.expected.dump
@@ -67,9 +67,9 @@ pub func hash14(val: string, init: Hash = 16777619): Hash {
 
 
 
-pub func String_op__lshift15(this: String, val: string): String {
+pub func OutputStream_op__lshift15(this: OutputStream, val: string): OutputStream {
   
-  String_appendString(this, ({
+  OutputStream_appendString(this, ({
     var s16 = CString{s = null}
     CString_op__init(&s16, val)
     s16
@@ -89,17 +89,17 @@ pub func Slice7_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice7_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 468, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
   this.data.[index] = data
 }
 
 pub func Slice7_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 474, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
   return this.data.[index]
 }
 
 pub func Slice7_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 480, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
   return this.data.[index]
 }
 
@@ -122,19 +122,19 @@ pub func Slice7_op__hash(this: const &Slice[string]): u32 {
 
 
 
-pub func Slice7_op__str(this: const &Slice[string], sb: String) {
-  String_appendChar(sb, '[')
+pub func Slice7_op__str(this: const &Slice[string], sb: OutputStream) {
+  OutputStream_appendChar(sb, '[')
   {
     const i = 0
     while (i != this.len)
     {
       if (i != 0) {
-        String_appendString(sb, ", ")
+        OutputStream_appendString(sb, ", ")
       }
-      String_op__lshift15(sb, this.data.[i])
+      OutputStream_op__lshift15(sb, this.data.[i])
     }
   }
-  String_appendChar(sb, ']')
+  OutputStream_appendChar(sb, ']')
 }
 
 struct __Closure17{ }


### PR DESCRIPTION
### Inheritance
- Adding minimal support for inheritance (currently 1 level)
- A class can implement `virtual` functions
  - Base classes can make their `virtual` functions pure by not providing a body. The presence of a pure `virtual` function makes the class abstract and no instance of the class can be created.
- Child classes can call members in the base class
- ⚠️ inheriting base class fields is still work in progress
- ⚠️ currently there is no support for `virtual` overloaded methods, intend to implement this at some point

```c
class OutputStream {
    virtual func write(msg: string) : i32

    func `<<`(x: string) : OutputStream {
        write(x)
       return this 
   }
}

class FileOutputStream : OutputStream {
    - fd: i32
    func `init`(fd: i32 = 1) { this.fd = fd }
    
    func write(msg: string): i32 => write(fd, msg, strlen!(msg))
}

class OutputNetworkStream : OutputStream {
    - driver: NetworkDriver
    func `init`(driver: NetworkDriver) { this.driver =  driver }
    
    func write(msg: string): i32 => driver.send(fd, msg, strlen!(msg))
}

func show(os: OutputStream, msg: string) {
    os << msg
}

func main() {
    var fos = FileOutputStream();
    var nos = NetworkOutputStream();
    show(fos, "Hello world from cxy")
    show(nos, "Hello world from cxy")

    fos << "\nShifted in from child class"
    nos << "\nShifted in from child class"
}
```