### PR TITLE
Adding support for reference counted memory

### DIFF
--- a/src/cxy/lang/backend/llvm/binary.cpp
+++ b/src/cxy/lang/backend/llvm/binary.cpp
@@ -84,7 +84,8 @@ void generateBinaryExpr(AstVisitor *visitor, AstNode *node)
 
     llvm::Value *lhs = NULL, *rhs = NULL;
 
-    if (left->type != right->type && !typeIs(left->type, Pointer)) {
+    if (left->type != right->type &&
+        !(typeIs(left->type, Pointer) || typeIs(left->type, Func))) {
         // implicitly cast to the bigger type
         if (isPrimitiveTypeBigger(left->type, right->type)) {
             rhs = ctx.generateCastExpr(visitor, left->type, right);

--- a/src/cxy/lang/frontend/ast.h
+++ b/src/cxy/lang/frontend/ast.h
@@ -291,6 +291,8 @@ struct AstNode {
         struct {
             cstring name;
             struct AstNode *args;
+            u32 count;
+            bool kvpArgs;
         } attr;
 
         struct {
@@ -1037,6 +1039,12 @@ AstNode *makeIndexExpr(MemPool *pool,
                        AstNode *next,
                        const Type *type);
 
+AstNode *makeAttribute(MemPool *pool,
+                       const FileLoc *loc,
+                       cstring name,
+                       AstNode *args,
+                       AstNode *next);
+
 AstNode *makeBackendCallExpr(MemPool *pool,
                              const FileLoc *loc,
                              u64 flags,
@@ -1158,9 +1166,14 @@ void setGenericDeclarationParams(AstNode *node, AstNode *params);
 
 const AstNode *findAttribute(const AstNode *node, cstring name);
 
-FileLoc *getDeclarationLoc(FileLoc *dst, const AstNode *node);
-
 const AstNode *findAttributeArgument(const AstNode *attr, cstring name);
+
+const AstNode *getAttributeArgument(Log *L,
+                                    const FileLoc *loc,
+                                    const AstNode *attr,
+                                    u32 index);
+
+FileLoc *getDeclarationLoc(FileLoc *dst, const AstNode *node);
 
 bool mapAstNode(HashTable *mapping, const AstNode *from, AstNode *to);
 

--- a/src/cxy/lang/frontend/strings.h
+++ b/src/cxy/lang/frontend/strings.h
@@ -75,6 +75,10 @@
     f(asyncLaunchMember)        \
     f(sync)                     \
     f(self)                     \
+    f(External)                 \
+    f(Appending)                \
+    f(linkage)                  \
+    f(section)                  \
     f(__init)                   \
     f(__startup)                \
     f(__name)                   \

--- a/src/cxy/lang/frontend/ttable.c
+++ b/src/cxy/lang/frontend/ttable.c
@@ -933,7 +933,7 @@ const Type *promoteType(TypeTable *table, const Type *left, const Type *right)
         return left;
 
     if ((typeIs(_left, String) || typeIs(_left, Pointer) ||
-         typeIs(_left, Opaque)) &&
+         typeIs(_left, Opaque) || typeIs(_left, Func)) &&
         typeIs(stripPointer(_right), Null))
         return left;
 

--- a/src/cxy/lang/middle/bind/scope.c
+++ b/src/cxy/lang/middle/bind/scope.c
@@ -224,7 +224,7 @@ AstNode *findSymbol(const Env *env,
 
     if (isBuiltinsInitialized()) {
         AstNode *node = findBuiltinDecl(name);
-        if (node)
+        if (hasFlag(node, Public))
             return node;
     }
 

--- a/src/cxy/lang/middle/sema/binary.c
+++ b/src/cxy/lang/middle/sema/binary.c
@@ -186,7 +186,7 @@ void checkBinaryExpr(AstVisitor *visitor, AstNode *node)
     case optEquality:
         if (!typeIs(type, Primitive) && !typeIs(type, Pointer) &&
             !typeIs(type, String) && !typeIs(type, Enum) &&
-            !typeIs(type, Opaque)) {
+            !typeIs(type, Opaque) && !typeIs(type, Func)) {
             logError(ctx->L,
                      &node->loc,
                      "cannot perform equality binary operation '{s}' on "

--- a/src/cxy/lang/middle/sema/call.c
+++ b/src/cxy/lang/middle/sema/call.c
@@ -24,17 +24,26 @@ static void reAssignCalleeType(AstNode *node, const Type *type)
 {
     if (nodeIs(node, Path)) {
         AstNode *elem = getLastAstNode(node->path.elements);
+        AstNode *resolved = elem->pathElement.resolvesTo;
         elem->type = type;
-        elem->pathElement.resolvesTo = type->func.decl;
+        if (!nodeIs(resolved, FuncParamDecl) && !nodeIs(resolved, FieldDecl))
+            elem->pathElement.resolvesTo = type->func.decl;
     }
     else if (nodeIs(node, MemberExpr)) {
         AstNode *member = node->memberExpr.member;
         member->type = type;
-        if (nodeIs(member, Identifier))
-            member->ident.resolvesTo = type->func.decl;
+        if (nodeIs(member, Identifier)) {
+            AstNode *resolved = member->ident.resolvesTo;
+            if (!nodeIs(resolved, FuncParamDecl) &&
+                !nodeIs(resolved, FieldDecl))
+                member->ident.resolvesTo = type->func.decl;
+        }
     }
-    else if (nodeIs(node, Identifier))
-        node->ident.resolvesTo = type->func.decl;
+    else if (nodeIs(node, Identifier)) {
+        AstNode *resolved = node->ident.resolvesTo;
+        if (!nodeIs(resolved, FuncParamDecl) && !nodeIs(resolved, FieldDecl))
+            node->ident.resolvesTo = type->func.decl;
+    }
     node->type = type;
 }
 

--- a/src/cxy/lang/middle/sema/generics.c
+++ b/src/cxy/lang/middle/sema/generics.c
@@ -35,8 +35,14 @@ static bool inferGenericFunctionTypes(AstVisitor *visitor,
 
     u64 argsCount = countAstNodes(arg);
 
-    if (argsCount == 0)
-        return false;
+    if (argsCount == 0) {
+        if (!hasFlag(param, Variadic))
+            return false;
+        call->callExpr.args =
+            makeTupleExpr(ctx->pool, &call->loc, flgNone, NULL, NULL, NULL);
+        argsCount = 1;
+        arg = call->callExpr.args;
+    }
 
     const Type **argTypes = mallocOrDie(sizeof(Type *) * argsCount);
     bool status = true;

--- a/src/cxy/lang/middle/sema/struct.c
+++ b/src/cxy/lang/middle/sema/struct.c
@@ -139,7 +139,7 @@ bool evalExplicitConstruction(AstVisitor *visitor,
                                 &node->loc,
                                 flgNone);
     if (constructor == NULL ||
-        findAttribute(constructor->func.decl, "explicit"))
+        findAttribute(constructor->func.decl, S_explicit))
         return false;
 
     if (constructor->func.paramsCount != 1)

--- a/src/cxy/lang/middle/simplify/simplify.c
+++ b/src/cxy/lang/middle/simplify/simplify.c
@@ -340,7 +340,7 @@ static void simplifyCastExpression(SimplifyContext *ctx,
                                    const Type *type)
 {
     const Type *from = unwrapType(node->type, NULL);
-    if (type == from)
+    if (type == from || typeIs(type, Func))
         return;
 
     if (!typeIs(from, Union)) {
@@ -742,13 +742,31 @@ static void simplifyMainModule(SimplifyContext *ctx, AstNode *program)
     AstNode *ctors = makeVarDecl(
         ctx->pool,
         builtinLoc(),
-        flgTopLevelDecl | flgConst | flgPublic,
+        flgTopLevelDecl | flgConst,
         makeString(ctx->strings, S___LLVM_global_ctors),
         NULL,
         makeArrayExpr(
             ctx->pool, builtinLoc(), flgConst, elems.first, NULL, type),
         NULL,
         type);
+    ctors->attrs = makeAttribute(
+        ctx->pool,
+        builtinLoc(),
+        S_linkage,
+        makeStringLiteral(ctx->pool,
+                          builtinLoc(),
+                          S_Appending,
+                          NULL,
+                          makeStringType(ctx->types)),
+        makeAttribute(ctx->pool,
+                      builtinLoc(),
+                      S_section,
+                      makeStringLiteral(ctx->pool,
+                                        builtinLoc(),
+                                        S_ctor_section,
+                                        NULL,
+                                        makeStringType(ctx->types)),
+                      NULL));
     getLastAstNode(program->program.decls)->next = ctors;
 }
 

--- a/src/cxy/runtime/builtins.cxy
+++ b/src/cxy/runtime/builtins.cxy
@@ -10,18 +10,8 @@ pub extern func abort(): void;
 pub extern func printf(s: string, ...args: auto): i32
 pub extern func write(fd: i32, buf: &const void, len: u64) : i64
 
-@[pure, inline]
-pub func __cxy_alloc(size: u64) => malloc(size)
-@[pure, inline]
-pub func __cxy_realloc(ptr: &void, size: u64) => realloc(ptr, size)
-@[pure, inline]
-pub func __cxy_calloc(size: u64) => memset(__cxy_alloc(size), 0, size)
-@[pure, inline]
-pub func __cxy_free(ptr: &void) { free(ptr) }
-
-
-@[pure, inline]
-pub func __cxy_assert(cond: bool, file: string, line: u64, column: u64) {
+@[pure, inline, linkage("External")]
+func __cxy_assert(cond: bool, file: string, line: u64, column: u64) {
     if (!cond) {
         var buf: [char, 64];
         write(2, "assertion failed: ", 18)
@@ -38,6 +28,78 @@ pub func __cxy_assert(cond: bool, file: string, line: u64, column: u64) {
 else {
     macro assert(cond) ()
 }
+
+@[pure, inline, linkage("External")]
+func __cxy_panic(file: string, line: u64, column: u64, msg: string) {
+    var buf: [char, 64];
+    write(2, "panic: ", 7)
+    write(2, msg, strlen(msg))
+    write(2, "\n  @", 4)
+    write(2, file, strlen(file))
+    var len = sprintf(buf, ":%u:%u\n", line, column);
+    write(2, buf, len)
+    abort()
+}
+
+macro panic(msg) __cxy_panic(file!, line!, column!, msg!)
+
+type sptr = &void
+
+struct __mem {
+    refs: u32
+    magic: i32
+    dctor: func(ptr: sptr) -> void
+}
+
+#const MEMORY_MAGIC = <i32>0xAEAEAEAE
+
+@[pure, linkage("External")]
+func __smart_ptr_alloc(size: u64, dctor: func(ptr: sptr) -> void = null) {
+    var ptr = malloc(size + sizeof!(__mem));
+    if (ptr == null) {
+        return ptr !: sptr
+    }
+
+    var mem = ptr !: &__mem;
+    mem.magic = #{MEMORY_MAGIC}
+    mem.refs = 1
+    mem.dctor = dctor
+    return ((ptr !: &u8) + sizeof!(__mem)) !: sptr
+}
+
+@[pure, inline, linkage("External")]
+func __smart_ptr_get(ptr: sptr) {
+    var mem = ((ptr !: &u8) + (-sizeof!(__mem))) !: &__mem;
+    if (mem.magic != #{MEMORY_MAGIC}) {
+        panic!("invalid smart pointer")
+    }
+    mem.refs++
+}
+
+@[pure, linkage("External")]
+func __smart_ptr_drop(ptr: sptr) {
+    if (ptr == null)
+        return;
+
+    var mem = ((ptr !: &u8) + (-sizeof!(__mem))) !: &__mem;
+    if (mem.magic != #{MEMORY_MAGIC}) {
+        panic!("invalid smart pointer")
+    }
+
+    mem.refs--
+    if (mem.refs == 0) {
+        // invoke destructor if available
+        if (mem.dctor != null) {
+            mem.dctor(ptr)
+        }
+
+        mem.magic = 0
+        free(mem !: &void)
+    }
+}
+
+@[pure, inline]
+pub func __calloc(size: u64) => memset(malloc(size), 0, size)
 
 /* Builtin Optional Type */
 struct __Optional[T] {
@@ -93,6 +155,7 @@ pub func hash_fnv1a_string(h: Hash, str: string)
     return h;
 }
 
+@[pure]
 pub func hash_fnv1a_bytes(h: Hash,
                          ptr: &const void,
                          size: u64)
@@ -103,6 +166,7 @@ pub func hash_fnv1a_bytes(h: Hash,
     return h
 }
 
+@[pure]
 pub func hash[T](val: const T, init: Hash = #{FNV_32_PRIME}) : Hash {
     #if (#T == #string) {
         return hash_fnv1a_string(init, val)
@@ -154,7 +218,7 @@ pub func hash[T](val: const T, init: Hash = #{FNV_32_PRIME}) : Hash {
     }
 }
 
-struct CString {
+pub struct CString {
     s: string = null
 
     @inline func `init`(s: string) { this.s = s }
@@ -171,7 +235,8 @@ struct CString {
 
 #const CXY_STRING_BUILDER_DEFAULT_CAPACITY = 32:u64
 
-class OutputStream {
+pub class OutputStream {
+    @[pure]
     virtual func append(str: &const char, size: u64): void
 
     @inline
@@ -248,7 +313,6 @@ class OutputStream {
         append(data, len)
     }
 
-    @inline
     func `<<`[U](val: const U) : OutputStream {
         #if (U.isString)
             #if (U.isClass)
@@ -318,7 +382,7 @@ class OutputStream {
     }
 }
 
-class String : OutputStream {
+pub class String : OutputStream {
     - _capacity: u64 = 0;
     - _size: u64 = 0;
     - _data: &char = null;
@@ -326,14 +390,14 @@ class String : OutputStream {
     - func grow(growSize: u64) {
         const newSize = _size + growSize;
         if (this._data == null) {
-            this._data = <&char> __cxy_alloc(growSize + 1)
+            this._data = <&char> malloc(growSize + 1)
             this._capacity = growSize
         }
         else if (this._capacity < newSize) {
             while (this._capacity < newSize) {
                 this._capacity <<= 1
             }
-            this._data = <&char> __cxy_realloc(this._data !: &void, this._capacity+1)
+            this._data = <&char> realloc(this._data !: &void, this._capacity+1)
         }
     }
 
@@ -348,7 +412,7 @@ class String : OutputStream {
     @inline
     func `deinit`() => {
         if (_data != null) {
-            __cxy_free(this._data)
+            free(this._data)
             this._data = null
         }
     }
@@ -459,7 +523,7 @@ class String : OutputStream {
     @inline const func data() => _data
 }
 
-class FileOutputStream : OutputStream {
+pub class FileOutputStream : OutputStream {
     - fd: i32
     func `init`(fd: i32 = 0) {
         this.fd = fd
@@ -527,34 +591,66 @@ pub struct Slice[T] {
     }
 }
 
-pub func allocate[T](len: u32 = 0) => {
-    var obj = __cxy_alloc(sizeof!(#T)) : T;
-    #if (T.isClass || T.isStruct) {
-        // this will ensure that default values are assigned
-        init_defaults!(obj)
-    }
-    return obj
+@[pure, inline]
+pub func ref[T](ptr: T) {
+    __smart_ptr_get(ptr: sptr)
+    return ptr
 }
 
-pub func make[T](...args: auto) => {
+@[pure, linkage("External")]
+func __deinit_fwd[T](ptr: sptr) {
+    (ptr !: &T).op__deinit()
+}
+
+pub func allocate[T](len: u32 = 0) {
     #if (T.isClass) {
-        var obj = __cxy_alloc(sizeof!(#T)) : T;
+        var obj: T;
+        #if (T.has_deinit) {
+            obj = (__smart_ptr_alloc(sizeof!(#T), __deinit_fwd[T]) !: T)
+        }
+        else {
+            obj = (__smart_ptr_alloc(sizeof!(#T)) !: T)
+        }
         // this will ensure that default values are assigned
         init_defaults!(obj)
-        obj.op__init(...args)
         return obj
     }
     else {
-        error!("type '{t}' unsupported by `make`", #T)
+        var obj: T;
+        #if (T.has_deinit) {
+            obj = <&T> __smart_ptr_alloc(sizeof!(#T), __deinit_fwd[T])
+        }
+        else {
+            obj = <&T> __smart_ptr_alloc(sizeof!(#T))
+        }
+
+        #if (T.isStruct)
+            // this will ensure that default values are assigned
+            init_defaults!(obj)
+
+        return obj
     }
+}
+
+pub func make[T](@transient ...args: auto) {
+    require!(T.isClass, "type '{t}' unsupported by `make`", #T)
+
+    var obj: T;
+    #if (T.has_deinit) {
+        obj = (__smart_ptr_alloc(sizeof!(#T), __deinit_fwd[T]) !: T)
+    }
+    else {
+        obj = (__smart_ptr_alloc(sizeof!(#T)) !: T)
+    }
+    // this will ensure that default values are assigned
+    init_defaults!(obj)
+    obj.op__init(...args)
+    return obj
 }
 
 @inline
 pub func deallocate[T](ptr: T) {
-    #if (T.has_deinit) {
-        ptr.op__deinit()
-    }
-    __cxy_free(ptr: &void)
+    __smart_ptr_drop(ptr: sptr)
 }
 
 pub var stdout: OutputStream = make[FileOutputStream](1);
@@ -562,16 +658,12 @@ pub var stderr: OutputStream = make[FileOutputStream](2);
 
 @inline
 pub func print[T](data: const T) {
-    #if (T.isString) {
-        #if (T.isClass) {
-            write(0, data.data(), data.size())
-        }
-        else {
-            write(0, data, strlen(data))
-        }
+    require!(T.isString, "type '{t}' is not a string, `print` only support string types", #T)
+    #if (T.isClass) {
+        write(0, data.data(), data.size())
     }
     else {
-        error!("'{t}' currently not supported", #T)
+        write(0, data, strlen(data))
     }
 }
 

--- a/src/cxy/stdlib/hash.cxy
+++ b/src/cxy/stdlib/hash.cxy
@@ -74,8 +74,8 @@ pub class HashMap[K, V] {
         var newCapacity = hashNextPrime(_capacity);
         if (newCapacity <= _capacity)
             newCapacity = _capacity * 2 + 1;
-        var newData = <&HashMapNode[K,V]> __cxy_calloc(sizeof!(#HashMapNode[K,V]) * newCapacity);
-        var newHashes = <&u32> __cxy_calloc(sizeof!(#u32) * newCapacity);
+        var newData = <&HashMapNode[K,V]> __calloc(sizeof!(#HashMapNode[K,V]) * newCapacity);
+        var newHashes = <&u32> __calloc(sizeof!(#u32) * newCapacity);
 
         var n = _capacity;
         for (const i: 0..n) {
@@ -91,8 +91,8 @@ pub class HashMap[K, V] {
             newHashes.[index] = hashCode;
         }
 
-        __cxy_free(_hashes: &void)
-        __cxy_free(_data: &void)
+        free(_hashes: &void)
+        free(_data: &void)
         _hashes = newHashes;
         _data = newData
         _capacity = newCapacity
@@ -121,8 +121,8 @@ pub class HashMap[K, V] {
 
     func `init`(_capacity: u64 = #{DEFAULT_HASH_TABLE_CAPACITY}) {
         _capacity = hashNextPrime(_capacity)
-        _data = <&HashMapNode[K,V]> __cxy_calloc(sizeof!(#HashMapNode[K,V]) * _capacity)
-        _hashes = <&u32> __cxy_calloc(sizeof!(#u32) * _capacity)
+        _data = <&HashMapNode[K,V]> __calloc(sizeof!(#HashMapNode[K,V]) * _capacity)
+        _hashes = <&u32> __calloc(sizeof!(#u32) * _capacity)
         this._capacity = _capacity
     }
 
@@ -134,8 +134,8 @@ pub class HashMap[K, V] {
                 }
             }
 
-            __cxy_free(_data: &void)
-            __cxy_free(_hashes: &void)
+            free(_data: &void)
+            free(_hashes: &void)
             _size = 0
             _capacity = 0
         }
@@ -276,8 +276,8 @@ pub class HashSet[K] {
         var newCapacity = hashNextPrime(_capacity);
         if (newCapacity <= _capacity)
             newCapacity = _capacity * 2 + 1;
-        var newData = <&HashMapNode[K, void]> __cxy_calloc(sizeof!(#HashMapNode[K, void]) * newCapacity);
-        var newHashes = <&u32> __cxy_calloc(sizeof!(#u32) * newCapacity);
+        var newData = <&HashMapNode[K, void]> __calloc(sizeof!(#HashMapNode[K, void]) * newCapacity);
+        var newHashes = <&u32> __calloc(sizeof!(#u32) * newCapacity);
 
         var n = _capacity;
         for (const i: 0..n) {
@@ -292,8 +292,8 @@ pub class HashSet[K] {
             newHashes.[index] = hashCode;
         }
 
-        __cxy_free(_hashes: &void)
-        __cxy_free(_data: &void)
+        free(_hashes: &void)
+        free(_data: &void)
         _hashes = newHashes;
         _data = newData
         _capacity = newCapacity
@@ -318,8 +318,8 @@ pub class HashSet[K] {
 
     func `init`(_capacity: u64 = #{DEFAULT_HASH_TABLE_CAPACITY}) {
         _capacity = hashNextPrime(_capacity)
-        _data = <&HashMapNode[K, void]> __cxy_calloc(sizeof!(#HashMapNode[K, void]) * _capacity)
-        _hashes = <&u32> __cxy_calloc(sizeof!(#u32) * _capacity)
+        _data = <&HashMapNode[K, void]> __calloc(sizeof!(#HashMapNode[K, void]) * _capacity)
+        _hashes = <&u32> __calloc(sizeof!(#u32) * _capacity)
         this._capacity = _capacity
     }
 
@@ -331,8 +331,8 @@ pub class HashSet[K] {
                 }
             }
 
-            __cxy_free(_data: &void)
-            __cxy_free(_hashes: &void)
+            free(_data: &void)
+            free(_hashes: &void)
             _size = 0
             _capacity = 0
         }

--- a/src/cxy/stdlib/vector.cxy
+++ b/src/cxy/stdlib/vector.cxy
@@ -10,13 +10,13 @@ pub class Vector[T] {
     - func grow() {
         if (_size >= _capacity) {
             _capacity += (_capacity / 2)
-            _data = <&T> __cxy_realloc(_data: &void, sizeof!(#T) * _capacity)
+            _data = <&T> realloc(_data: &void, sizeof!(#T) * _capacity)
         }
     }
 
     func `init`(initialSize: u64 = #{DEFAULT_VECTOR_CAPACITY}) {
         _capacity = initialSize
-        _data = <&T> __cxy_alloc(sizeof!(#T) * _capacity)
+        _data = <&T> malloc(sizeof!(#T) * _capacity)
     }
 
     @inline
@@ -26,7 +26,7 @@ pub class Vector[T] {
                 _data.[i] = null
             }
         }
-        __cxy_free(_data: &void)
+        free(_data: &void)
     }
 
     func push(item: T) {
@@ -50,7 +50,7 @@ pub class Vector[T] {
     }
 
     func resize(newSize: u64) {
-        _data = <&T> __cxy_realloc(_data: &void, sizeof!(#T) * newSize)
+        _data = <&T> realloc(_data: &void, sizeof!(#T) * newSize)
         if (newSize < _size)
             _size = newSize
        _capacity = newSize;

--- a/tests/hello.cxy
+++ b/tests/hello.cxy
@@ -1,7 +1,17 @@
-import { Vector } from "stdlib/vector.cxy"
+//import { Vector } from "stdlib/vector.cxy"
 
-type Users = Vector[i32]
+class Demo {
+    func `init`() {
+        stdout << "Initializing....\n"
+    }
+
+    func `deinit`() {
+        stdout << "De-initializing....\n"
+    }
+}
 
 pub func main() {
-    var x = Users();
+    var x = make[Demo]();
+    ref(x)
+    deallocate(x)
 }

--- a/tests/lang/closure.expected.dump
+++ b/tests/lang/closure.expected.dump
@@ -94,17 +94,17 @@ pub func Slice10_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice10_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 552, 9)
   this.data.[index] = data
 }
 
 pub func Slice10_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 558, 9)
   return this.data.[index]
 }
 
 pub func Slice10_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 564, 9)
   return this.data.[index]
 }
 
@@ -149,9 +149,15 @@ pub func __Closure20_op__call(this: &__Closure20): i8 {
 }
 
 
+func __deinit_fwd23(ptr: sptr) {
+  String_op__deinit(((ptr : &class String)))
+}
+
+
 
 pub func allocate22(len: u32 = 0): String {
-  var obj = (__cxy_alloc(__bc(0, #String)) : class String)
+  var obj: class String
+  obj = ((__smart_ptr_alloc(__bc(0, #String), __deinit_fwd23) : class String))
   {
     obj.vtable = &String_vTable
     obj._capacity = 0
@@ -161,10 +167,10 @@ pub func allocate22(len: u32 = 0): String {
   return obj
 }
 
-struct __Closure23{ }
+struct __Closure24{ }
 
 
-pub func __Closure23_op__call(this: &__Closure23, name: string): String {
+pub func __Closure24_op__call(this: &__Closure24, name: string): String {
   var s21 = allocate22(<u32>0)
   String_op__init(s21)
   var sb7 = s21
@@ -173,36 +179,23 @@ pub func __Closure23_op__call(this: &__Closure23, name: string): String {
 }
 
 
-pub func OutputStream_op__lshift25(this: OutputStream, val: i8): OutputStream {
+pub func OutputStream_op__lshift26(this: OutputStream, val: i8): OutputStream {
   
   OutputStream_appendSignedInt(this, <i64>val)
   return this
 }
 
-struct __Closure26 {
+struct __Closure27 {
   - b: string
   - x: i8
 }
 
-pub func __Closure26_op__call(this: &__Closure26): String {
-  var s24 = allocate22(<u32>0)
-  String_op__init(s24)
-  var sb8 = s24
-  OutputStream_op__lshift25(OutputStream_op__lshift18(OutputStream_op__lshift18(<OutputStream>sb8, this.b), " -> "), this.x)
+pub func __Closure27_op__call(this: &__Closure27): String {
+  var s25 = allocate22(<u32>0)
+  String_op__init(s25)
+  var sb8 = s25
+  OutputStream_op__lshift26(OutputStream_op__lshift18(OutputStream_op__lshift18(<OutputStream>sb8, this.b), " -> "), this.x)
   return sb8
-}
-
-struct __Closure28 {
-  - b: string
-  - x: i8
-}
-
-pub func __Closure28_op__call(this: &__Closure28): String {
-  var s27 = allocate22(<u32>0)
-  String_op__init(s27)
-  var sb9 = s27
-  OutputStream_op__lshift25(OutputStream_op__lshift18(OutputStream_op__lshift18(<OutputStream>sb9, this.b), " -> "), this.x)
-  return sb9
 }
 
 struct __Closure29 {
@@ -210,34 +203,47 @@ struct __Closure29 {
   - x: i8
 }
 
-pub func __Closure29_op__call(this: &__Closure29) {
-  const g = __Closure28{b = b, x = x}
+pub func __Closure29_op__call(this: &__Closure29): String {
+  var s28 = allocate22(<u32>0)
+  String_op__init(s28)
+  var sb9 = s28
+  OutputStream_op__lshift26(OutputStream_op__lshift18(OutputStream_op__lshift18(<OutputStream>sb9, this.b), " -> "), this.x)
+  return sb9
 }
 
-struct __Closure30{ }
+struct __Closure30 {
+  - b: string
+  - x: i8
+}
 
-pub func __Closure30_op__call(this: &__Closure30) { }
-
-
-func __Closure30__fwd(ptr: &void): void => __Closure30_op__call(<&__Closure30>ptr)
+pub func __Closure30_op__call(this: &__Closure30) {
+  const g = __Closure29{b = b, x = x}
+}
 
 struct __Closure31{ }
 
-pub func __Closure31_op__call(this: &__Closure31, msg: string) { }
+pub func __Closure31_op__call(this: &__Closure31) { }
 
 
-func __Closure31__fwd(ptr: &void, msg: string): void => __Closure31_op__call(<&__Closure31>ptr, msg)
+func __Closure31__fwd(ptr: &void): void => __Closure31_op__call(<&__Closure31>ptr)
+
+struct __Closure32{ }
+
+pub func __Closure32_op__call(this: &__Closure32, msg: string) { }
+
+
+func __Closure32__fwd(ptr: &void, msg: string): void => __Closure32_op__call(<&__Closure32>ptr, msg)
 
 func main(args: Slice10) {
   const one = __Closure20{}
   __Closure20_op__call(&one)
-  __Closure23_op__call(&(__Closure23{}), "User")
+  __Closure24_op__call(&(__Closure24{}), "User")
   var x = 100
   var b = "Hello"
-  __Closure26_op__call(&(__Closure26{b = b, x = x}))
-  const f = __Closure29{b = b, x = x}
-  closureArg0((<&void>&__Closure30{}, __Closure30__fwd))
-  closureArg2((<&void>&__Closure31{}, __Closure31__fwd))
+  __Closure27_op__call(&(__Closure27{b = b, x = x}))
+  const f = __Closure30{b = b, x = x}
+  closureArg0((<&void>&__Closure31{}, __Closure31__fwd))
+  closureArg2((<&void>&__Closure32{}, __Closure32__fwd))
 }
 
 const llvm.global_ctors = [(0, __init, null)]

--- a/tests/lang/literals.expected.dump
+++ b/tests/lang/literals.expected.dump
@@ -82,17 +82,17 @@ pub func Slice7_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice7_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 552, 9)
   this.data.[index] = data
 }
 
 pub func Slice7_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 558, 9)
   return this.data.[index]
 }
 
 pub func Slice7_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 564, 9)
   return this.data.[index]
 }
 

--- a/tests/lang/tuples.expected.dump
+++ b/tests/lang/tuples.expected.dump
@@ -90,17 +90,17 @@ pub func Slice7_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice7_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 552, 9)
   this.data.[index] = data
 }
 
 pub func Slice7_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 558, 9)
   return this.data.[index]
 }
 
 pub func Slice7_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 564, 9)
   return this.data.[index]
 }
 

--- a/tests/lang/varargs.expected.dump
+++ b/tests/lang/varargs.expected.dump
@@ -82,17 +82,17 @@ pub func Slice7_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice7_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 552, 9)
   this.data.[index] = data
 }
 
 pub func Slice7_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 558, 9)
   return this.data.[index]
 }
 
 pub func Slice7_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 564, 9)
   return this.data.[index]
 }
 

--- a/tests/lang/variables.expected.dump
+++ b/tests/lang/variables.expected.dump
@@ -84,17 +84,17 @@ pub func Slice8_op__init(this: &Slice[string], data: &string, len: u64) {
 
 
 pub func Slice8_op__idx_assign(this: &Slice[string], index: i64, data: string) {
-  __cxy_assert(index < this.len, "__builtins.cxy", 488, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 552, 9)
   this.data.[index] = data
 }
 
 pub func Slice8_op__idx(this: &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 494, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 558, 9)
   return this.data.[index]
 }
 
 pub func Slice8_op__idx(this: const &Slice[string], index: i64): string {
-  __cxy_assert(index < this.len, "__builtins.cxy", 500, 9)
+  __cxy_assert(index < this.len, "__builtins.cxy", 564, 9)
   return this.data.[index]
 }
 


### PR DESCRIPTION
* Adding support for reference memory allocator.
 * `allocate` can now be used to allocate shared memory for any type
 * `make` can be used to allocated class instance
 * `malloc` and co are still available to use
 * `__calloc` is an alternative to native `calloc`
 * `deallocate` can be used to drop a reference
* Added a `panic!` macro, (🅿️ need to implement back tracing)
* Added support `linkage("External"|"Appending")` attribute function
* Added support for `section` attribute