### PR TITLE
Adding support for importing C-header files using clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c99-designator -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c99-designator -Werror -fno-rtti")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
@@ -39,6 +39,7 @@ include(CxyUtils)
 include(FetchContent)
 
 find_package(LLVM REQUIRED CONFIG)
+find_package(Clang REQUIRED)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(${LLVM_INCLUDE_DIRS})
@@ -90,10 +91,6 @@ CxyAmalgamate(builtins
         FILES
         src/cxy/runtime/builtins.cxy)
 
-
-set(CXY_3RD_PARTY_SOURCES
-        src/3rdParty/cJSON.c)
-
 set(CXY_CORE_SOURCES
         src/cxy/core/args.c
         src/cxy/core/array.c
@@ -117,6 +114,7 @@ set(CXY_FRONTEND_SOURCES
         src/cxy/lang/frontend/defines.c
         src/cxy/lang/frontend/decode.c
         src/cxy/lang/frontend/lexer.c
+        src/cxy/lang/frontend/module.c
         src/cxy/lang/frontend/operator.c
         src/cxy/lang/frontend/parser.c
         src/cxy/lang/frontend/strings.c
@@ -149,7 +147,6 @@ set(CXY_MIDDLE_SOURCES
         src/cxy/lang/middle/sema/interface.c
         src/cxy/lang/middle/sema/match.c
         src/cxy/lang/middle/sema/member.c
-        src/cxy/lang/middle/sema/module.c
         src/cxy/lang/middle/sema/new.c
         src/cxy/lang/middle/sema/node.c
         src/cxy/lang/middle/sema/path.c
@@ -202,7 +199,11 @@ set(CXY_DRIVER_SOURCES
         src/cxy/driver/driver.c
         src/cxy/driver/options.c
         src/cxy/driver/stages.c
-        src/cxy/driver/stats.c)
+        src/cxy/driver/stats.c
+
+        src/cxy/driver/c-import/context.cpp
+        src/cxy/driver/c-import/import.cpp
+)
 
 add_executable(cxy
         src/cxy/driver/main.c
@@ -224,7 +225,7 @@ llvm_map_components_to_libnames(llvm_libs
         TransformUtils
         CodeGen
 )
-
+list(APPEND llvm_libs clangAST clangBasic clangFrontend clangLex clangParse clangSema)
 message(STATUS ${llvm_libs})
 target_link_libraries(cxy msgpack-c yaml ${llvm_libs})
 target_compile_definitions(cxy PRIVATE

--- a/src/cxy/core/log.c
+++ b/src/cxy/core/log.c
@@ -108,7 +108,8 @@ Log newLog(DiagnosticHandler handler, void *ctx)
                   .handler = handler,
                   .handlerCtx = ctx,
                   .maxErrors = SIZE_MAX,
-                  .enabledWarnings.num = wrnAll & ~BIT(wrnMissingStage)};
+                  .enabledWarnings.num = wrnAll & ~(BIT(wrnMissingStage) |
+                                                    BIT(wrnCMacroRedefine))};
     if (handler == printDiagnosticToConsole) {
         L.handlerCtx = NULL;
         L.handler = NULL;

--- a/src/cxy/core/log.h
+++ b/src/cxy/core/log.h
@@ -13,7 +13,8 @@ extern "C" {
 #define CXY_COMPILER_WARNINGS(f)        \
     f(MissingStage,      0)             \
     f(UnusedVariable,    1)             \
-    f(RedundantStmt,     2)
+    f(RedundantStmt,     2)             \
+    f(CMacroRedefine,    3)
 
 // clang-format on
 
@@ -124,6 +125,12 @@ static inline FileLoc *locAfter(FileLoc *dst, const FileLoc *loc)
 }
 
 u64 parseWarningLevels(Log *L, cstring str);
+
+static inline bool isWarningEnabled_(Log *L, WarningId id)
+{
+    return L->enabledWarnings.num & id;
+}
+#define isWarningEnabled(L, NAME) isWarningEnabled_((L), BIT(wrn##NAME))
 
 #ifdef __cplusplus
 }

--- a/src/cxy/driver/c-import/context.cpp
+++ b/src/cxy/driver/c-import/context.cpp
@@ -1,0 +1,84 @@
+//
+// Created by Carter Mbotho on 2024-04-29.
+//
+
+#include "context.hpp"
+#include "import.hpp"
+
+extern "C" {
+#include "lang/frontend/flag.h"
+#include "lang/frontend/ttable.h"
+}
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace cxy {
+
+IncludeContext::IncludeContext(CompilerDriver *driver,
+                               clang::CompilerInstance &ci)
+    : L{driver->L}, pool{driver->pool}, strings{driver->strings},
+      types{driver->types}, preprocessor{&driver->preprocessor},
+      target{ci.getTarget()}, SM{ci.getSourceManager()},
+      importer{*((cxy::CImporter *)driver->cImporter)}
+{
+}
+
+AstNodeList *IncludeContext::enterFile(clang::StringRef path)
+{
+    auto module = modules.find(path);
+    if (module == modules.end()) {
+        modules.insert({path, AstNodeList{}});
+        return &modules[path];
+    }
+    else {
+        return &module->second;
+    }
+}
+
+void IncludeContext::addDeclaration(AstNode *node)
+{
+    if (node == nullptr)
+        return;
+
+    auto path = clang::StringRef(node->loc.fileName ?: "__c_builtins.cxy");
+    if (auto module = enterFile(path)) {
+        insertAstNode(module, node);
+    }
+}
+
+AstNode *IncludeContext::buildModules(llvm::StringRef mainModulePath)
+{
+    AstNode *mainModule = nullptr;
+    for (auto &[path, nodes] : modules) {
+        FileLoc moduleLoc = {
+            .fileName = makeStringSized(strings, path.data(), path.size()),
+            .begin = {.row = 1, .col = 1, .byteOffset = 0},
+            .end = {.row = 1, .col = 1, .byteOffset = 0}};
+        auto name = fs::path(path.data()).stem().string();
+        auto program = makeProgramAstNode(
+            pool,
+            &moduleLoc,
+            flgImportedModule | flgNative,
+            makeModuleAstNode(
+                pool,
+                &loc,
+                flgNative,
+                makeStringSized(strings, name.data(), name.size()),
+                nullptr,
+                nullptr),
+            NULL,
+            nodes.first,
+            NULL);
+
+        buildModuleType(types, program, false);
+        importer.add(path, program);
+        if (path == mainModulePath)
+            mainModule = program;
+    }
+
+    return mainModule;
+}
+
+} // namespace cxy

--- a/src/cxy/driver/c-import/context.hpp
+++ b/src/cxy/driver/c-import/context.hpp
@@ -1,0 +1,38 @@
+//
+// Created by Carter Mbotho on 2024-04-29.
+//
+
+#pragma once
+
+extern "C" {
+#include "driver/driver.h"
+#undef make
+}
+
+#include <clang/Frontend/CompilerInstance.h>
+#include <llvm/ADT/StringRef.h>
+
+namespace cxy {
+class CImporter;
+
+struct IncludeContext {
+    IncludeContext(CompilerDriver *driver, clang::CompilerInstance &ci);
+
+    void addDeclaration(AstNode *node);
+    AstNode *buildModules(llvm::StringRef mainModulePath);
+
+    Log *L{nullptr};
+    MemPool *pool{nullptr};
+    StrPool *strings{nullptr};
+    TypeTable *types{nullptr};
+    CompilerPreprocessor *preprocessor{nullptr};
+    clang::TargetInfo &target;
+    clang::SourceManager &SM;
+    llvm::DenseMap<llvm::StringRef, AstNodeList> modules{};
+    cxy::CImporter &importer;
+    FileLoc loc{};
+
+private:
+    AstNodeList *enterFile(clang::StringRef path);
+};
+} // namespace cxy

--- a/src/cxy/driver/c-import/import.cpp
+++ b/src/cxy/driver/c-import/import.cpp
@@ -1,0 +1,843 @@
+//
+// Created by Carter Mbotho on 2024-04-26.
+//
+
+#include "import.hpp"
+#include "context.hpp"
+
+extern "C" {
+#include "core/alloc.h"
+#include "core/strpool.h"
+#include "driver/c.h"
+#include "lang/frontend/defines.h"
+#include "lang/frontend/flag.h"
+#include "lang/frontend/ttable.h"
+}
+
+#undef make
+#undef Pair
+
+#pragma warning(push, 0)
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclGroup.h>
+#include <clang/AST/PrettyPrinter.h>
+#include <clang/AST/Type.h>
+#include <clang/Basic/TargetInfo.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Lex/HeaderSearch.h>
+#include <clang/Lex/Preprocessor.h>
+#include <clang/Lex/PreprocessorOptions.h>
+#include <clang/Parse/ParseAST.h>
+#include <clang/Sema/Sema.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/ErrorHandling.h>
+#include <llvm/Support/Path.h>
+#include <llvm/TargetParser/Host.h>
+#pragma warning(pop)
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace cxy {
+
+static const Type *getIntegerTypeFromBitWidth(TypeTable *types,
+                                              int bitWidth,
+                                              bool isSigned)
+{
+    switch (bitWidth) {
+    case 8:
+        return getPrimitiveType(types, isSigned ? prtI8 : prtU8);
+    case 16:
+        return getPrimitiveType(types, isSigned ? prtI16 : prtU16);
+    case 32:
+        return getPrimitiveType(types, isSigned ? prtI32 : prtU32);
+    case 64:
+        return getPrimitiveType(types, isSigned ? prtI64 : prtU64);
+    default:
+        unreachable("invalid integer bit width");
+    }
+}
+
+static const Type *toCxy(IncludeContext &ctx, const clang::BuiltinType &type)
+{
+    switch (type.getKind()) {
+    case clang::BuiltinType::Void:
+        return makeVoidType(ctx.types);
+    case clang::BuiltinType::Bool:
+        return getPrimitiveType(ctx.types, prtBool);
+    case clang::BuiltinType::Char_S:
+        return getPrimitiveType(ctx.types, prtCChar);
+    case clang::BuiltinType::Char_U:
+        return getPrimitiveType(ctx.types, prtChar);
+    case clang::BuiltinType::SChar:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getCharWidth(), true);
+    case clang::BuiltinType::UChar:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getCharWidth(), false);
+    case clang::BuiltinType::Short:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getShortWidth(), true);
+    case clang::BuiltinType::UShort:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getShortWidth(), false);
+    case clang::BuiltinType::Int:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getIntWidth(), true);
+    case clang::BuiltinType::UInt:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getIntWidth(), false);
+    case clang::BuiltinType::Long:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getLongWidth(), true);
+    case clang::BuiltinType::ULong:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getLongWidth(), false);
+    case clang::BuiltinType::LongLong:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getLongLongWidth(), true);
+    case clang::BuiltinType::ULongLong:
+        return getIntegerTypeFromBitWidth(
+            ctx.types, ctx.target.getLongLongWidth(), false);
+    case clang::BuiltinType::Float16:
+    case clang::BuiltinType::Float:
+        return getPrimitiveType(ctx.types, prtF32);
+    case clang::BuiltinType::Double:
+    case clang::BuiltinType::LongDouble:
+        return getPrimitiveType(ctx.types, prtF64);
+    default:
+        unreachable("unsupported C type ");
+    }
+}
+
+static cstring getCDeclName(IncludeContext &ctx, const clang::TagDecl &decl)
+{
+    auto name = decl.getName();
+    if (!name.empty()) {
+        return makeStringSized(ctx.strings, name.data(), name.size());
+    }
+    else if (auto *typedefNameDecl = decl.getTypedefNameForAnonDecl()) {
+        name = typedefNameDecl->getName();
+        return makeStringSized(ctx.strings, name.data(), name.size());
+    }
+    return "";
+}
+
+static cstring getCDeclName(IncludeContext &ctx, const clang::NamedDecl &decl)
+{
+    auto name = decl.getName();
+    if (!name.empty()) {
+        return makeStringSized(ctx.strings, name.data(), name.size());
+    }
+    return "";
+}
+
+static const Type *toCxy(IncludeContext &ctx, clang::QualType qualtype);
+
+static const Type *withFlags(IncludeContext &ctx, const Type *type, u64 flags)
+{
+    if ((type->flags & flags) != flags)
+        return makeWrappedType(ctx.types, type, flags);
+    return type;
+}
+
+static FilePos toCxy(IncludeContext &ctx, const clang::SourceLocation &loc)
+{
+    auto presumedLoc = ctx.SM.getPresumedLoc(loc);
+    if (!loc.isValid()) {
+        return {};
+    }
+
+    return {.row = presumedLoc.getLine(),
+            .col = presumedLoc.getColumn(),
+            .byteOffset = ctx.SM.getFileOffset(loc)};
+}
+
+static FileLoc toCxy(IncludeContext &ctx, const clang::Decl &decl)
+{
+    if (decl.getLocation().isValid()) {
+        auto start = toCxy(ctx, decl.getSourceRange().getBegin());
+        auto end = toCxy(ctx, decl.getSourceRange().getEnd());
+        auto filename = ctx.SM.getFilename(decl.getLocation());
+        ctx.loc = FileLoc{.fileName = makeStringSized(
+                              ctx.strings, filename.data(), filename.size()),
+                          .begin = start,
+                          .end = end};
+    };
+    return ctx.loc;
+}
+
+static FileLoc toCxy(IncludeContext &ctx, const clang::SourceRange &range)
+{
+    if (range.isValid()) {
+        auto start = toCxy(ctx, range.getBegin());
+        auto end = toCxy(ctx, range.getEnd());
+        auto filename = ctx.SM.getFilename(range.getBegin());
+        ctx.loc = FileLoc{.fileName = makeStringSized(
+                              ctx.strings, filename.data(), filename.size()),
+                          .begin = start,
+                          .end = end};
+    }
+    return ctx.loc;
+}
+
+static FileLoc toCxy(IncludeContext &ctx, const clang::Token &token)
+{
+    if (token.getLocation().isValid()) {
+        auto start = toCxy(ctx, token.getLocation());
+        auto end = toCxy(ctx, token.getEndLoc());
+        auto filename = ctx.SM.getFilename(token.getLocation());
+        ctx.loc = FileLoc{.fileName = makeStringSized(
+                              ctx.strings, filename.data(), filename.size()),
+                          .begin = start,
+                          .end = end};
+    }
+    return ctx.loc;
+}
+
+static AstNode *toCxy(IncludeContext &ctx, const clang::RecordDecl *record)
+{
+    auto loc = toCxy(ctx, llvm::cast<clang::Decl>(*record));
+    auto node = AstNode{.tag = astTypeDecl,
+                        .flags = flgExtern | flgPublic,
+                        .structDecl = {.name = getCDeclName(ctx, *record)}};
+
+    auto decl = makeAstNode(ctx.pool, &loc, &node);
+    decl->type = makeOpaqueType(ctx.types, getDeclarationName(decl), decl);
+    return decl;
+}
+
+static AstNode *toCxy(IncludeContext &ctx, const clang::EnumDecl *enum_)
+{
+    auto range = enum_->getSourceRange();
+    auto loc = toCxy(ctx, enum_->getSourceRange());
+    auto node = AstNode{.tag = astEnumDecl,
+                        .flags = flgExtern | flgPublic,
+                        .structDecl = {.name = getCDeclName(ctx, *enum_)}};
+
+    auto decl = makeAstNode(ctx.pool, &loc, &node);
+    decl->type = makeOpaqueType(ctx.types, getDeclarationName(decl), decl);
+    return decl;
+}
+
+static const Type *toCxy(IncludeContext &ctx,
+                         const clang::FunctionProtoType &proto)
+{
+    std::vector<const Type *> params;
+    params.reserve(proto.getNumParams());
+    for (int i = 0; i < proto.getNumParams(); i++) {
+        params.push_back(toCxy(ctx, proto.getParamType(i)));
+    }
+    Type func = {.tag = typFunc,
+                 .flags = (proto.isVariadic() ? flgVariadic : flgNone) |
+                          flgExtern | flgPublic,
+                 .func = {
+                     .paramsCount = (u16)params.size(),
+                     .retType = toCxy(ctx, proto.getReturnType()),
+                     .params = params.data(),
+                 }};
+
+    auto type = makeFuncType(ctx.types, &func);
+    return type;
+}
+
+static const Type *toCxy(IncludeContext &ctx,
+                         const clang::FunctionNoProtoType &proto)
+{
+    Type func = {.tag = typFunc,
+                 .flags = flgExtern | flgPublic,
+                 .func = {
+                     .retType = toCxy(ctx, proto.getReturnType()),
+                 }};
+
+    return makeFuncType(ctx.types, &func);
+}
+
+static const Type *toCxy(IncludeContext &ctx, const clang::QualType qualtype)
+{
+    u64 flags = qualtype.isConstQualified() ? flgConst : flgNone;
+    auto &type = *qualtype.getTypePtr();
+    switch (type.getTypeClass()) {
+    case clang::Type::Pointer: {
+        auto pointee = llvm::cast<clang::PointerType>(type).getPointeeType();
+        if (pointee->isFunctionType()) {
+            return toCxy(ctx, pointee);
+        }
+        return makePointerType(ctx.types, toCxy(ctx, pointee), flags);
+    }
+    case clang::Type::Builtin:
+        return withFlags(
+            ctx, toCxy(ctx, llvm::cast<clang::BuiltinType>(type)), flags);
+    case clang::Type::Typedef: {
+        auto desugared = llvm::cast<clang::TypedefType>(type).desugar();
+        if (flags & flgConst)
+            desugared.addConst();
+        return toCxy(ctx, desugared);
+    }
+    case clang::Type::Elaborated:
+        return toCxy(ctx,
+                     llvm::cast<clang::ElaboratedType>(type).getNamedType());
+    case clang::Type::Record: {
+        auto record = llvm::cast<clang::RecordType>(type).getDecl();
+        return toCxy(ctx, record)->type;
+    }
+    case clang::Type::Paren:
+        return toCxy(ctx, llvm::cast<clang::ParenType>(type).getInnerType());
+    case clang::Type::FunctionNoProto:
+        return toCxy(ctx, llvm::cast<clang::FunctionNoProtoType>(type));
+    case clang::Type::FunctionProto:
+        return toCxy(ctx, llvm::cast<clang::FunctionProtoType>(type));
+    case clang::Type::ConstantArray: {
+        auto &constArray = llvm::cast<clang::ConstantArrayType>(type);
+        if (!constArray.getSize().isIntN(64)) {
+            logError(ctx.L, builtinLoc(), "array is too large", nullptr);
+        }
+        return makeArrayType(ctx.types,
+                             toCxy(ctx, constArray.getElementType()),
+                             constArray.getSize().getLimitedValue());
+    }
+    case clang::Type::IncompleteArray:
+        return makePointerType(
+            ctx.types,
+            toCxy(
+                ctx,
+                llvm::cast<clang::IncompleteArrayType>(type).getElementType()),
+            flags);
+    case clang::Type::Attributed:
+        return toCxy(
+            ctx, llvm::cast<clang::AttributedType>(type).getEquivalentType());
+    case clang::Type::Decayed:
+        return toCxy(ctx,
+                     llvm::cast<clang::DecayedType>(type).getDecayedType());
+    case clang::Type::Enum: {
+        auto &enumType = llvm::cast<clang::EnumType>(type);
+        auto name = getCDeclName(ctx, *enumType.getDecl());
+
+        if (name[0] == '\0') {
+            return withFlags(
+                ctx, toCxy(ctx, enumType.getDecl()->getIntegerType()), flags);
+        }
+        else {
+            return withFlags(ctx, toCxy(ctx, enumType.getDecl())->type, flags);
+        }
+    }
+    default:
+        logWarning(ctx.L,
+                   builtinLoc(),
+                   "unhandled C type class '{s}' (importing type '{s}')",
+                   (FormatArg[]){{.s = type.getTypeClassName()},
+                                 {.s = qualtype.getAsString().data()}});
+        return getPrimitiveType(ctx.types, prtI32);
+    }
+}
+
+static AstNode *toCxy(IncludeContext &ctx, const clang::FieldDecl &decl)
+{
+    if (decl.getName().empty())
+        return nullptr;
+    auto loc = toCxy(ctx, llvm::cast<clang::Decl>(decl));
+    auto type = toCxy(ctx, decl.getType());
+    auto node = makeStructField(ctx.pool,
+                                &loc,
+                                getCDeclName(ctx, decl),
+                                flgPublic,
+                                makeTypeReferenceNode(ctx.pool, type, &loc),
+                                nullptr,
+                                nullptr);
+    node->type = type;
+    return node;
+}
+
+static AstNode *toCxy(IncludeContext &ctx, const clang::RecordDecl &decl)
+{
+    auto loc = toCxy(ctx, llvm::cast<clang::Decl>(decl));
+    AstNodeList fields = {};
+    auto node = makeStructDecl(ctx.pool,
+                               &loc,
+                               flgPublic,
+                               getCDeclName(ctx, decl),
+                               nullptr,
+                               nullptr,
+                               nullptr);
+    std::vector<NamedTypeMember> members;
+    for (auto *field : decl.fields()) {
+        if (auto fieldDecl = toCxy(ctx, *field)) {
+            insertAstNode(&fields, fieldDecl);
+            members.push_back(
+                NamedTypeMember{.name = fieldDecl->structField.name,
+                                .type = fieldDecl->type,
+                                .decl = fieldDecl});
+            fieldDecl->parentScope = node;
+        }
+        else {
+            logError(ctx.L, &loc, "cxy cannot import unnamed C types", nullptr);
+            return nullptr;
+        }
+    }
+    node->type = makeStructType(ctx.types,
+                                node->structDecl.name,
+                                members.data(),
+                                members.size(),
+                                node,
+                                flgExtern | flgPublic);
+    return node;
+}
+
+static AstNode *toCxy(IncludeContext &ctx, const clang::TypedefDecl &decl)
+{
+    auto loc = toCxy(ctx, decl.getSourceRange());
+    auto type = toCxy(ctx, decl.getUnderlyingType());
+    return makeTypeDeclAstNode(ctx.pool,
+                               &loc,
+                               flgExtern | flgPublic,
+                               getCDeclName(ctx, decl),
+                               makeTypeReferenceNode(ctx.pool, type, &loc),
+                               NULL,
+                               type);
+}
+
+static AstNode *toCxy(IncludeContext &ctx, const clang::VarDecl &decl)
+{
+    auto loc = toCxy(ctx, llvm::cast<clang::Decl>(decl));
+    auto type = toCxy(ctx, decl.getType());
+    return makeVarDecl(ctx.pool,
+                       &loc,
+                       flgNone,
+                       getCDeclName(ctx, decl),
+                       makeTypeReferenceNode(ctx.pool, type, &loc),
+                       nullptr,
+                       nullptr,
+                       type);
+}
+
+AstNode *toCxy(IncludeContext &ctx, const clang::FunctionDecl &decl)
+{
+    auto loc = toCxy(ctx, llvm::cast<clang::Decl>(decl));
+    std::vector<const Type *> paramTypes{};
+    AstNodeList params = {};
+
+    for (int i = 0; i < decl.getNumParams(); i++) {
+        auto &param = *decl.getParamDecl(i);
+        auto paramLoc = toCxy(ctx, llvm::cast<clang::Decl>(param));
+        paramTypes.push_back(toCxy(ctx, param.getType()));
+        insertAstNode(&params,
+                      makeFunctionParam(ctx.pool,
+                                        &paramLoc,
+                                        getCDeclName(ctx, param),
+                                        makeTypeReferenceNode(
+                                            ctx.pool, paramTypes[i], &paramLoc),
+                                        nullptr,
+                                        flgNone,
+                                        nullptr));
+    }
+
+    Type func = {.tag = typFunc,
+                 .name = getCDeclName(ctx, decl),
+                 .flags = (decl.isVariadic() ? flgVariadic : flgNone) |
+                          flgExtern | flgPublic,
+                 .func = {
+                     .paramsCount = (u16)paramTypes.size(),
+                     .retType = toCxy(ctx, decl.getReturnType()),
+                     .params = paramTypes.data(),
+                 }};
+
+    auto retLoc = toCxy(ctx, decl.getReturnTypeSourceRange());
+    auto node = makeFunctionDecl(
+        ctx.pool,
+        &loc,
+        func.name,
+        params.first,
+        makeTypeReferenceNode(
+            ctx.pool, toCxy(ctx, decl.getReturnType()), &retLoc),
+        nullptr,
+        flgExtern | flgPublic,
+        nullptr,
+        nullptr);
+
+    func.func.decl = node;
+    node->type = makeFuncType(ctx.types, &func);
+
+    return node;
+}
+
+AstNode *toCxy(IncludeContext &ctx, const clang::EnumDecl &decl)
+{
+    auto name = getCDeclName(ctx, decl);
+    auto type = toCxy(ctx,
+                      name[0] ? decl.getIntegerType()
+                              : clang::QualType(decl.getTypeForDecl(), 0));
+    auto loc = toCxy(ctx, decl.getSourceRange());
+    AstNodeList options = {};
+    std::vector<EnumOptionDecl> members;
+    int i = 0;
+    for (clang::EnumConstantDecl *option : decl.enumerators()) {
+        auto memberName = makeStringSized(
+            ctx.strings, option->getName().data(), option->getName().size());
+        auto &value = option->getInitVal();
+        auto optionLoc = toCxy(ctx, option->getSourceRange());
+        auto expr = makeIntegerLiteral(
+            ctx.pool, &optionLoc, value.getExtValue(), nullptr, type);
+        insertAstNode(&options,
+                      makeEnumOptionAst(ctx.pool,
+                                        &optionLoc,
+                                        flgNone,
+                                        memberName,
+                                        expr,
+                                        nullptr,
+                                        nullptr));
+
+        members.emplace_back((EnumOptionDecl){
+            .name = memberName,
+            .value = value.getExtValue(),
+            .decl = options.last,
+        });
+    }
+
+    auto node = makeEnumAst(ctx.pool,
+                            &loc,
+                            flgNative | flgPublic,
+                            name,
+                            makeTypeReferenceNode(ctx.pool, type, builtinLoc()),
+                            options.first,
+                            nullptr,
+                            nullptr);
+
+    Type enum_ = {.tag = typEnum,
+                  .name = name,
+                  .flags = flgExtern,
+                  .tEnum = {.base = type,
+                            .options = members.data(),
+                            .optionsCount = members.size(),
+                            .decl = node}};
+    node->type = makeEnum(ctx.types, &enum_);
+    return node;
+}
+
+struct CToCxyConverter : clang::ASTConsumer {
+
+    explicit CToCxyConverter(IncludeContext &ctx) : ctx(ctx) {}
+
+    bool HandleTopLevelDecl(clang::DeclGroupRef declGroup) final override
+    {
+        for (clang::Decl *decl : declGroup) {
+            auto loc = ctx.SM.getPresumedLoc(decl->getLocation());
+            if (ctx.importer.find(loc.getFilename()))
+                continue;
+
+            switch (decl->getKind()) {
+            case clang::Decl::Function:
+                ctx.addDeclaration(
+                    toCxy(ctx, *llvm::cast<clang::FunctionDecl>(decl)));
+                break;
+            case clang::Decl::Record: {
+                if (!decl->isFirstDecl())
+                    break;
+
+                ctx.addDeclaration(
+                    toCxy(ctx, llvm::cast<clang::RecordDecl>(*decl)));
+                break;
+            }
+            case clang::Decl::Enum: {
+                ctx.addDeclaration(
+                    toCxy(ctx, llvm::cast<clang::EnumDecl>(*decl)));
+                break;
+            }
+            case clang::Decl::Var:
+                ctx.addDeclaration(
+                    toCxy(ctx, llvm::cast<clang::VarDecl>(*decl)));
+                break;
+            case clang::Decl::Typedef:
+                ctx.addDeclaration(
+                    toCxy(ctx, llvm::cast<clang::TypedefDecl>(*decl)));
+                break;
+            default:
+                break;
+            }
+        }
+        return true; // continue parsing
+    }
+
+private:
+    IncludeContext &ctx;
+};
+
+struct MacroImporter : clang::PPCallbacks {
+    MacroImporter(IncludeContext &ctx,
+                  clang::CompilerInstance &compilerInstance)
+        : ctx(ctx), compilerInstance(compilerInstance)
+    {
+    }
+
+    void MacroDefined(const clang::Token &name,
+                      const clang::MacroDirective *macro) final override
+    {
+        if (macro->getMacroInfo()->getNumTokens() != 1)
+            return;
+        auto loc = ctx.SM.getPresumedLoc(name.getLocation());
+        if (ctx.importer.find(loc.getFilename()))
+            return;
+
+        auto &token = macro->getMacroInfo()->getReplacementToken(0);
+
+        switch (token.getKind()) {
+        case clang::tok::numeric_constant:
+            importMacroConstant(name.getIdentifierInfo()->getName(),
+                                token,
+                                toCxy(ctx, name.getLocation()));
+            break;
+        default:
+            break;
+        }
+    }
+
+private:
+    void importMacroConstant(llvm::StringRef name,
+                             const clang::Token &token,
+                             FilePos start)
+    {
+        auto result = compilerInstance.getSema().ActOnNumericConstant(token);
+        if (!result.isUsable())
+            return;
+        clang::Expr *parsed = result.get();
+        auto loc = toCxy(ctx, token);
+        loc.begin = start;
+        if (auto *intLiteral = llvm::dyn_cast<clang::IntegerLiteral>(parsed)) {
+            auto type = toCxy(ctx, parsed->getType());
+            llvm::APSInt value(intLiteral->getValue(),
+                               parsed->getType()->isUnsignedIntegerType());
+            auto macro = makeMacroDeclAstNode(
+                ctx.pool,
+                &loc,
+                flgPublic | flgExtern,
+                makeStringSized(ctx.strings, name.data(), name.size()),
+                NULL,
+                makeIntegerLiteral(
+                    ctx.pool, builtinLoc(), value.getSExtValue(), NULL, type),
+                NULL);
+            defineMacro(macro);
+        }
+        else if (auto *floatLiteral =
+                     llvm::dyn_cast<clang::FloatingLiteral>(parsed)) {
+            auto value = floatLiteral->getValue();
+            auto type = toCxy(ctx, parsed->getType());
+            auto macro = makeMacroDeclAstNode(
+                ctx.pool,
+                &loc,
+                flgPublic | flgExtern,
+                makeStringSized(ctx.strings, name.data(), name.size()),
+                NULL,
+                makeFloatLiteral(ctx.pool,
+                                 builtinLoc(),
+                                 value.convertToDouble(),
+                                 NULL,
+                                 type),
+                NULL);
+            defineMacro(macro);
+        }
+    }
+
+    void defineMacro(AstNode *node)
+    {
+        AstNode *previous = NULL;
+        if (preprocessorOverrideDefinedMacro(
+                ctx.preprocessor, node->macroDecl.name, node, &previous)) //
+        {
+            return;
+        }
+
+        if (isWarningEnabled(ctx.L, CMacroRedefine)) {
+            logWarning(
+                ctx.L,
+                &node->loc,
+                "overriding macro with name '{s}' which was already defined",
+                (FormatArg[]){{.s = node->macroDecl.name}});
+            if (previous && previous->loc.fileName != NULL) {
+                logNote(ctx.L,
+                        &previous->loc,
+                        "macro previously declared here",
+                        NULL);
+            }
+        }
+    }
+
+private:
+    IncludeContext &ctx;
+    clang::CompilerInstance &compilerInstance;
+};
+
+} // namespace cxy
+
+template <typename T, typename R>
+static auto map(DynArray &arr, std::function<R(T &)> func) -> std::vector<R>
+{
+    std::vector<R> mapped;
+    for (int i = 0; i < arr.size; i++) {
+        mapped.push_back(func(dynArrayAt(T *, &arr, i)));
+    }
+    return mapped;
+}
+
+template <typename T>
+static auto for_each(DynArray &arr, std::function<void(T &)> func)
+{
+    for (int i = 0; i < arr.size; i++) {
+        func(dynArrayAt(T *, &arr, i));
+    }
+}
+
+static std::string removeSDKVersion(clang::StringRef path)
+{
+    static std::string sSDKVersion{};
+    if (sSDKVersion.empty()) {
+        FormatState state = newFormatState(nullptr, true);
+        exec("xcrun --show-sdk-version", &state);
+        auto version = formatStateToString(&state);
+        version[strlen(version) - 1] = '\0';
+        freeFormatState(&state);
+        sSDKVersion = std::string(version);
+        free(version);
+    }
+    auto str = path.str();
+    auto index = path.find(sSDKVersion);
+    if (index == std::string::npos)
+        return str;
+    str.erase(index, sSDKVersion.size());
+    return str;
+}
+
+AstNode *importCHeader(CompilerDriver *driver,
+                       const AstNode *node,
+                       cstring name)
+{
+    auto importer = (cxy::CImporter *)driver->cImporter;
+    cstring importerPath = node->loc.fileName;
+    cstring headerName = node->stringLiteral.value;
+    auto &options = driver->options;
+    clang::CompilerInstance ci;
+    ci.createDiagnostics();
+    auto args =
+        map<cstring, cstring>(options.cflags, [](auto cflag) { return cflag; });
+    clang::CompilerInvocation::CreateFromArgs(
+        ci.getInvocation(), args, ci.getDiagnostics());
+
+    std::shared_ptr<clang::TargetOptions> pto =
+        std::make_shared<clang::TargetOptions>();
+    pto->Triple = llvm::sys::getDefaultTargetTriple();
+    auto targetInfo =
+        clang::TargetInfo::CreateTargetInfo(ci.getDiagnostics(), pto);
+    ci.setTarget(targetInfo);
+
+    ci.createFileManager();
+    ci.createSourceManager(ci.getFileManager());
+    ci.getHeaderSearchOpts().AddPath(llvm::sys::path::parent_path(importerPath),
+                                     clang::frontend::Quoted,
+                                     false,
+                                     true);
+
+    cxy::IncludeContext context(driver, ci);
+
+    for_each<cstring>(options.importSearchPaths, [&ci](auto path) {
+        ci.getHeaderSearchOpts().AddPath(
+            path, clang::frontend::System, false, true);
+        ci.getHeaderSearchOpts().AddPath(
+            path, clang::frontend::System, false, false);
+    });
+
+    for_each<cstring>(options.frameworkSearchPaths, [&ci](auto path) {
+        ci.getHeaderSearchOpts().AddPath(
+            path, clang::frontend::System, true, true);
+        ci.getHeaderSearchOpts().AddPath(
+            path, clang::frontend::System, true, false);
+    });
+
+    for_each<cstring>(options.cDefines, [&ci](auto define) {
+        ci.getPreprocessorOpts().addMacroDef(define);
+    });
+    // prevent a warning that comes when importing C headers
+    ci.getPreprocessorOpts().addMacroDef("__GNUC__=4");
+
+    ci.createPreprocessor(clang::TU_Complete);
+    auto &pp = ci.getPreprocessor();
+    pp.getBuiltinInfo().initializeBuiltins(pp.getIdentifierTable(),
+                                           pp.getLangOpts());
+
+    clang::HeaderSearch &headerSearch =
+        ci.getPreprocessor().getHeaderSearchInfo();
+    auto fileEntry = headerSearch.LookupFile(headerName,
+                                             {},
+                                             false,
+                                             nullptr,
+                                             nullptr,
+                                             {},
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr,
+                                             nullptr);
+    if (!fileEntry) {
+        std::string searchDirs;
+        for (auto searchDir = headerSearch.search_dir_begin(),
+                  end = headerSearch.search_dir_end();
+             searchDir != end;
+             ++searchDir) {
+            searchDirs += searchDir->getName();
+            searchDirs += ' ';
+        }
+        logError(driver->L,
+                 &node->loc,
+                 "couldn't find C header file '{s}' (search dirs: {s})",
+                 (FormatArg[]){{.s = headerName}, {.s = searchDirs.data()}});
+        return NULL;
+    }
+
+    auto requestPath = fileEntry->getFileEntry().tryGetRealPathName();
+#ifdef __APPLE__
+    auto requestPathString = removeSDKVersion(requestPath.str());
+    requestPath = clang::StringRef(requestPathString);
+#endif
+    if (auto module = importer->find(requestPath))
+        return module;
+
+    ci.setASTConsumer(std::make_unique<cxy::CToCxyConverter>(context));
+    ci.createASTContext();
+    ci.createSema(clang::TU_Complete, nullptr);
+    pp.addPPCallbacks(std::make_unique<cxy::MacroImporter>(context, ci));
+
+    auto fileID = ci.getSourceManager().createFileID(
+        *fileEntry, clang::SourceLocation(), clang::SrcMgr::C_System);
+    ci.getSourceManager().setMainFileID(fileID);
+    ci.getDiagnosticClient().BeginSourceFile(ci.getLangOpts(),
+                                             &ci.getPreprocessor());
+    clang::ParseAST(
+        ci.getPreprocessor(), &ci.getASTConsumer(), ci.getASTContext());
+    ci.getDiagnosticClient().EndSourceFile();
+    ci.getDiagnosticClient().finish();
+
+    if (ci.getDiagnosticClient().getNumErrors() > 0) {
+        return NULL;
+    }
+
+    auto program = context.buildModules(requestPath);
+    csAssert(program != nullptr, "Something broken with c importer");
+    return program;
+}
+
+bool isCHeaderFile(cstring filePath)
+{
+    return fs::path(filePath).extension() == ".h";
+}
+
+void initCImporter(struct CompilerDriver *driver)
+{
+    csAssert0(driver->cImporter == nullptr);
+    driver->cImporter = new cxy::CImporter();
+}
+
+void deinitCImporter(struct CompilerDriver *driver)
+{
+    auto importer = (cxy::CImporter *)driver->cImporter;
+    if (importer)
+        delete importer;
+}

--- a/src/cxy/driver/c-import/import.hpp
+++ b/src/cxy/driver/c-import/import.hpp
@@ -1,0 +1,38 @@
+//
+// Created by Carter Mbotho on 2024-04-27.
+//
+
+#pragma once
+
+extern "C" {
+#include "driver/driver.h"
+#undef make
+}
+
+#include <clang/Basic/TargetInfo.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <llvm/ADT/DenseMap.h>
+
+#include <set>
+#include <unordered_map>
+
+namespace cxy {
+
+class CImporter {
+public:
+    AstNode *find(clang::StringRef path)
+    {
+        auto module = modules.find(path);
+        return module == modules.end() ? nullptr : module->second;
+    }
+
+    void add(clang::StringRef path, AstNode *module)
+    {
+        modules.try_emplace(path, module);
+    }
+
+private:
+    llvm::DenseMap<clang::StringRef, AstNode *> modules{};
+};
+
+} // namespace cxy

--- a/src/cxy/driver/c.h
+++ b/src/cxy/driver/c.h
@@ -1,0 +1,18 @@
+//
+// Created by Carter Mbotho on 2024-04-26.
+//
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "driver.h"
+
+AstNode *importCHeader(CompilerDriver *driver,
+                       const AstNode *node,
+                       cstring name);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/cxy/driver/driver.h
+++ b/src/cxy/driver/driver.h
@@ -30,6 +30,7 @@ typedef struct CompilerDriver {
     AstNodeList startup;
     CompilerPreprocessor preprocessor;
     void *backend;
+    void *cImporter;
 } CompilerDriver;
 
 typedef struct {
@@ -66,10 +67,13 @@ bool compileString(CompilerDriver *driver,
 
 const Type *compileModule(CompilerDriver *driver,
                           const AstNode *source,
-                          AstNode *entities);
+                          AstNode *entities,
+                          AstNode *alias);
 
 void *initCompilerBackend(CompilerDriver *driver, int argc, char **argv);
 void deinitCompilerBackend(CompilerDriver *driver);
 bool compilerBackendMakeExecutable(CompilerDriver *driver);
 void initCompilerPreprocessor(struct CompilerDriver *driver);
 void deinitCompilerPreprocessor(struct CompilerDriver *driver);
+void initCImporter(struct CompilerDriver *driver);
+void deinitCImporter(struct CompilerDriver *driver);

--- a/src/cxy/driver/options.h
+++ b/src/cxy/driver/options.h
@@ -45,8 +45,11 @@ typedef struct Options {
     const char *buildDir;
     const char *rest;
     DynArray cflags;
-    DynArray libraries;
+    DynArray cDefines;
     DynArray librarySearchPaths;
+    DynArray importSearchPaths;
+    DynArray frameworkSearchPaths;
+    DynArray libraries;
     DynArray defines;
     bool withoutBuiltins;
     bool noPIE;

--- a/src/cxy/driver/stages.c
+++ b/src/cxy/driver/stages.c
@@ -376,7 +376,7 @@ AstNode *executeCompilerStage(CompilerDriver *driver,
         logWarningWithId(driver->L,
                          wrnMissingStage,
                          NULL,
-                         "unsupported compiler id '{s}'",
+                         "unsupported compiler stage id '{s}'",
                          (FormatArg[]){{.s = stageName}});
         return node;
     }

--- a/src/cxy/lang/frontend/ast.c
+++ b/src/cxy/lang/frontend/ast.c
@@ -1144,6 +1144,113 @@ AstNode *makeBackendCallExpr(MemPool *pool,
                    .backendCallExpr = {.func = func, .args = args}});
 }
 
+AstNode *makeEnumOptionAst(MemPool *pool,
+                           const FileLoc *loc,
+                           u64 flags,
+                           cstring name,
+                           AstNode *value,
+                           AstNode *next,
+                           const Type *type)
+{
+    return makeAstNode(
+        pool,
+        loc,
+        &(AstNode){.tag = astEnumOptionDecl,
+                   .flags = flags,
+                   .type = type,
+                   .next = NULL,
+                   .enumOption = {.name = name, .value = value}});
+}
+
+AstNode *makeEnumAst(MemPool *pool,
+                     const FileLoc *loc,
+                     u64 flags,
+                     cstring name,
+                     AstNode *base,
+                     AstNode *options,
+                     AstNode *next,
+                     const Type *type)
+{
+    return makeAstNode(
+        pool,
+        loc,
+        &(AstNode){
+            .tag = astEnumDecl,
+            .flags = flags,
+            .type = type,
+            .next = NULL,
+            .enumDecl = {.base = base, .name = name, .options = options}});
+}
+
+AstNode *makeProgramAstNode(MemPool *pool,
+                            const FileLoc *loc,
+                            u64 flags,
+                            AstNode *module,
+                            AstNode *top,
+                            AstNode *decls,
+                            const Type *type)
+{
+    return makeAstNode(
+        pool,
+        loc,
+        &(AstNode){.tag = astProgram,
+                   .flags = flags,
+                   .type = type,
+                   .next = NULL,
+                   .program = {.module = module, .top = top, .decls = decls}});
+}
+
+AstNode *makeModuleAstNode(MemPool *pool,
+                           const FileLoc *loc,
+                           u64 flags,
+                           cstring name,
+                           Env *env,
+                           const Type *type)
+{
+    return makeAstNode(pool,
+                       loc,
+                       &(AstNode){.tag = astModuleDecl,
+                                  .flags = flags,
+                                  .type = type,
+                                  .next = NULL,
+                                  .moduleDecl = {.name = name, .env = env}});
+}
+
+AstNode *makeTypeDeclAstNode(MemPool *pool,
+                             const FileLoc *loc,
+                             u64 flags,
+                             cstring name,
+                             AstNode *aliased,
+                             AstNode *next,
+                             const Type *type)
+{
+    return makeAstNode(
+        pool,
+        loc,
+        &(AstNode){.tag = astTypeDecl,
+                   .flags = flags,
+                   .type = type,
+                   .next = next,
+                   .typeDecl = {.name = name, .aliased = aliased}});
+}
+
+AstNode *makeMacroDeclAstNode(MemPool *pool,
+                              const FileLoc *loc,
+                              u64 flags,
+                              cstring name,
+                              AstNode *params,
+                              AstNode *body,
+                              AstNode *next)
+{
+    return makeAstNode(
+        pool,
+        loc,
+        &(AstNode){
+            .tag = astMacroDecl,
+            .flags = flags,
+            .macroDecl = {.name = name, .params = params, .body = body}});
+}
+
 AstNode *makeAstClosureCapture(MemPool *pool, AstNode *captured)
 {
     return makeAstNode(pool,

--- a/src/cxy/lang/frontend/ast.h
+++ b/src/cxy/lang/frontend/ast.h
@@ -221,6 +221,7 @@ struct AstNode {
             struct AstNode *module;
             struct AstNode *top;
             struct AstNode *decls;
+            cstring path;
         } program;
 
         struct {
@@ -1057,6 +1058,54 @@ AstNode *makeBackendCallExpr(MemPool *pool,
                              BackendFuncId func,
                              AstNode *args,
                              const Type *type);
+
+AstNode *makeEnumOptionAst(MemPool *pool,
+                           const FileLoc *loc,
+                           u64 flags,
+                           cstring name,
+                           AstNode *value,
+                           AstNode *next,
+                           const Type *type);
+
+AstNode *makeEnumAst(MemPool *pool,
+                     const FileLoc *loc,
+                     u64 flags,
+                     cstring name,
+                     AstNode *base,
+                     AstNode *options,
+                     AstNode *next,
+                     const Type *type);
+
+AstNode *makeProgramAstNode(MemPool *pool,
+                            const FileLoc *loc,
+                            u64 flags,
+                            AstNode *module,
+                            AstNode *top,
+                            AstNode *decls,
+                            const Type *type);
+
+AstNode *makeModuleAstNode(MemPool *pool,
+                           const FileLoc *loc,
+                           u64 flags,
+                           cstring name,
+                           Env *env,
+                           const Type *type);
+
+AstNode *makeTypeDeclAstNode(MemPool *pool,
+                             const FileLoc *loc,
+                             u64 flags,
+                             cstring name,
+                             AstNode *aliased,
+                             AstNode *next,
+                             const Type *type);
+
+AstNode *makeMacroDeclAstNode(MemPool *pool,
+                              const FileLoc *loc,
+                              u64 flags,
+                              cstring name,
+                              AstNode *params,
+                              AstNode *body,
+                              AstNode *next);
 
 AstNode *makeAstClosureCapture(MemPool *pool, AstNode *captured);
 

--- a/src/cxy/lang/frontend/defines.c
+++ b/src/cxy/lang/frontend/defines.c
@@ -97,6 +97,7 @@ void initCompilerPreprocessor(struct CompilerDriver *driver)
         preprocessorDefineMacro(&driver->preprocessor,
                                 makeString(driver->strings, define->name),
                                 node);
+        freeLexer(&lexer);
     }
 }
 

--- a/src/cxy/lang/frontend/module.c
+++ b/src/cxy/lang/frontend/module.c
@@ -2,7 +2,7 @@
 // Created by Carter Mbotho on 2024-01-09.
 //
 
-#include "check.h"
+#include "lang/middle/sema/check.h"
 
 #include "lang/frontend/flag.h"
 #include "lang/frontend/strings.h"
@@ -50,7 +50,7 @@ static u64 addModuleTypeMember(NamedTypeMember *members,
     return index;
 }
 
-void buildModuleType(TypingContext *ctx, AstNode *node, bool isBuiltinModule)
+void buildModuleType(TypeTable *types, AstNode *node, bool isBuiltinModule)
 {
     u64 builtinsFlags = (isBuiltinModule ? flgBuiltin : flgNone);
     u64 count = countProgramDecls(node->program.decls) +
@@ -72,15 +72,10 @@ void buildModuleType(TypingContext *ctx, AstNode *node, bool isBuiltinModule)
     }
 
     node->type = makeModuleType(
-        ctx->types,
+        types,
         isBuiltinModule ? S___builtins : node->program.module->moduleDecl.name,
         node->loc.fileName,
         members,
         i);
     free(members);
-}
-
-void checkImportDecl(attr(unused) AstVisitor *visitor,
-                     attr(unused) AstNode *node)
-{
 }

--- a/src/cxy/lang/frontend/parser.c
+++ b/src/cxy/lang/frontend/parser.c
@@ -2538,7 +2538,7 @@ static AstNode *parseImportDecl(Parser *P)
     if (entities == NULL && match(P, tokAs))
         alias = parseIdentifier(P);
 
-    exports = compileModule(P->cc, module, entities);
+    exports = compileModule(P->cc, module, entities, alias);
     if (exports == NULL) {
         logWarning(P->L,
                    &tok.fileLoc,

--- a/src/cxy/lang/frontend/strings.h
+++ b/src/cxy/lang/frontend/strings.h
@@ -82,6 +82,8 @@
     f(__init)                   \
     f(__startup)                \
     f(__name)                   \
+    f(__construct0)             \
+    f(__construct1)             \
     f(__fwd)                    \
     f(CXY__main)                \
     ff(__LLVM_global_ctors, "llvm.global_ctors") \

--- a/src/cxy/lang/frontend/ttable.h
+++ b/src/cxy/lang/frontend/ttable.h
@@ -195,6 +195,8 @@ const Type *expectInType(TypeTable *table,
                          cstring name,
                          const FileLoc *loc);
 
+void buildModuleType(TypeTable *types, AstNode *node, bool isBuiltinModule);
+
 const Type *getIntegerTypeForLiteral(TypeTable *table, i64 literal);
 
 bool isIntegerTypeInRange(const Type *type, i64 min, i64 max);

--- a/src/cxy/lang/middle/eval/path.c
+++ b/src/cxy/lang/middle/eval/path.c
@@ -52,6 +52,21 @@ void evalPath(AstVisitor *visitor, AstNode *node)
             }
             symbol = option->enumOption.value;
         }
+        else if (nodeIs(symbol, ImportDecl)) {
+            cstring name = elem->pathElement.alt ?: elem->pathElement.name;
+            AstNode *member = findMemberDeclInType(symbol->type, name);
+            if (member == NULL) {
+                logError(
+                    ctx->L,
+                    &node->loc,
+                    "module {s} does not define a comptime variable named {s}",
+                    (FormatArg[]){{.s = symbol->type->name}, {.s = name}});
+
+                node->tag = astError;
+                return;
+            }
+            symbol = member;
+        }
         else {
             while (elem) {
                 cstring name = elem->pathElement.alt ?: elem->pathElement.name;

--- a/src/cxy/lang/middle/preprocess/preprocessor.c
+++ b/src/cxy/lang/middle/preprocess/preprocessor.c
@@ -254,5 +254,7 @@ AstNode *preprocessAst(CompilerDriver *driver, AstNode *node)
 
     astVisit(&visitor, node);
 
+    environmentFree(&env);
+    
     return node;
 }

--- a/src/cxy/lang/middle/sema/check.c
+++ b/src/cxy/lang/middle/sema/check.c
@@ -392,7 +392,7 @@ static void checkProgram(AstVisitor *visitor, AstNode *node)
     }
 
     if (isBuiltinModule || node->program.module) {
-        buildModuleType(ctx, node, isBuiltinModule);
+        buildModuleType(ctx->types, node, isBuiltinModule);
     }
 }
 
@@ -604,7 +604,7 @@ AstNode *checkAst(CompilerDriver *driver, AstNode *node)
         [astStructDecl] = checkStructDecl,
         [astClassDecl] = checkClassDecl,
         [astInterfaceDecl] = checkInterfaceDecl,
-        [astImportDecl] = checkImportDecl,
+        [astImportDecl] = astVisitSkip,
         [astReturnStmt] = checkReturnStmt,
         [astBlockStmt] = checkBlockStmt,
         [astDeferStmt] = checkDeferStmt,

--- a/src/cxy/lang/middle/sema/check.h
+++ b/src/cxy/lang/middle/sema/check.h
@@ -170,8 +170,6 @@ static inline const Type *checkType(AstVisitor *visitor, AstNode *node)
 const Type *checkFunctionSignature(AstVisitor *visitor, AstNode *node);
 const Type *checkFunctionBody(AstVisitor *visitor, AstNode *node);
 
-void buildModuleType(TypingContext *ctx, AstNode *node, bool isBuiltinModule);
-
 void checkVarDecl(AstVisitor *visitor, AstNode *node);
 void checkPath(AstVisitor *visitor, AstNode *node);
 void checkFunctionParam(AstVisitor *visitor, AstNode *node);
@@ -182,7 +180,6 @@ void checkFunctionDecl(AstVisitor *visitor, AstNode *node);
 void checkEnumDecl(AstVisitor *visitor, AstNode *node);
 void checkTypeDecl(AstVisitor *visitor, AstNode *node);
 void checkUnionDecl(AstVisitor *visitor, AstNode *node);
-void checkImportDecl(AstVisitor *visitor, attr(unused) AstNode *node);
 void checkGenericDecl(AstVisitor *visitor, AstNode *node);
 
 void checkBinaryExpr(AstVisitor *visitor, AstNode *node);

--- a/src/cxy/lang/middle/sema/path.c
+++ b/src/cxy/lang/middle/sema/path.c
@@ -193,4 +193,7 @@ void checkPath(AstVisitor *visitor, AstNode *node)
 
     node->type = type;
     node->flags |= flags;
+    if (hasFlag(node, Comptime)) {
+        node->type = checkType(visitor, node);
+    }
 }

--- a/src/cxy/lang/middle/sema/struct.c
+++ b/src/cxy/lang/middle/sema/struct.c
@@ -268,8 +268,10 @@ void checkStructExpr(AstVisitor *visitor, AstNode *node)
         initialized[member->decl->structField.index] = true;
     }
 
-    if (node->type == ERROR_TYPE(ctx))
+    if (node->type == ERROR_TYPE(ctx)) {
+        free(initialized);
         return;
+    }
 
     for (u64 i = 0; i < striped->tStruct.members->count; i++) {
         const AstNode *targetField = striped->tStruct.members->members[i].decl;
@@ -303,6 +305,7 @@ void checkStructExpr(AstVisitor *visitor, AstNode *node)
 
     if (node->type != ERROR_TYPE(ctx))
         node->type = target;
+    free(initialized);
 }
 
 void checkStructDecl(AstVisitor *visitor, AstNode *node)

--- a/src/cxy/runtime/builtins.cxy
+++ b/src/cxy/runtime/builtins.cxy
@@ -111,8 +111,8 @@ pub func __calloc(size: u64) => memset(malloc(size), 0, size)
 /* Builtin Optional Type */
 struct __Optional[T] {
     /* @note: Do not change the order of these members */
-    - ok: bool = false;
-    - val: T
+    ok: bool = false;
+    val: T
 
     @inline func `init`() { ok = false }
     @inline func `init`(value: T) { val = value; ok = true }
@@ -125,11 +125,11 @@ struct __Optional[T] {
 
 /* Creates a valid optional value */
 @inline
-pub func Some[T](@transient value: T) => __Optional[T](value)
+pub func Some[T](@transient value: T) => __Optional[T]{ok: true, val: value}
 
 /* Creates an invalid optional value */
 @inline
-pub func None[T]() => __Optional[T]()
+pub func None[T]() => __construct1[__Optional[T]]()
 
 pub type Hash = u32
 #const FNV_32_PRIME = 0x01000193
@@ -325,7 +325,7 @@ pub class OutputStream {
             #if (U.isClass)
                 append(val._data:  &const char, val.size())
             else
-                appendString(val)
+                appendString(__construct1[CString](val))
         else #if (U.isInteger)
             appendSignedInt(<i64>val)
         else #if (U.isFloat)
@@ -747,7 +747,7 @@ pub func allocate[T](len: u32 = 0) {
     }
 }
 
-pub func make[T](@transient ...args: auto) {
+pub func __construct0[T](@transient ...args: auto) {
     require!(T.isClass, "type '{t}' unsupported by `make`", #T)
 
     var obj = (__smart_ptr_alloc(sizeof!(#T), __deinit_fwd[T]) !: T);
@@ -758,13 +758,24 @@ pub func make[T](@transient ...args: auto) {
 }
 
 @[inline, pure]
-pub func deallocate[T](ptr: T) {
+pub func __construct1[T](@transient ...args: auto) {
+    require!(T.isStruct, "type '{t}' unsupported by `create`, only structs can be created", #T)
+
+    var obj: T;
+    // this will ensure that default values are assigned
+    init_defaults!(obj)
+    obj.op__init(...args)
+    return obj
+}
+
+@[inline, pure]
+pub func __destructor[T](ptr: T) {
     require!(T.isClass, "expecting type of deallocated object to be a class")
     __smart_ptr_drop(ptr: sptr)
 }
 
-pub var stdout: OutputStream = make[FileOutputStream](1);
-pub var stderr: OutputStream = make[FileOutputStream](2);
+pub var stdout: OutputStream = __construct0[FileOutputStream](1);
+pub var stderr: OutputStream = __construct0[FileOutputStream](2);
 
 @inline
 pub func print[T](data: const T) {

--- a/src/cxy/stdlib/io.cxy
+++ b/src/cxy/stdlib/io.cxy
@@ -1,37 +1,6 @@
 module io
 
-import "./c.cxy" as C
-
-pub func print[T](it: const T) {
-    @flatten
-    #if (T.isString) {
-        @flatten
-        #if (T.isStruct) {
-            C.write(C.STDOUT, it.str, it.count)
-        }
-        else {
-            C.write(C.STDOUT, it: string, len!(it))
-        }
-    }
-    else {
-        var j;
-        var str = f"${it}";
-        C.write(C.STDOUT, str.str, str.count)
-    }
-}
-
-@inline
-pub func println(@transient ...args: const auto) {
-    #const i = 0;
-
-    @flatten
-    #for (const T: args) {
-        print[#{T}](args.#{i})
-        #{i += 1}
-    }
-
-    C.write(C.STDOUT, "\n" : &const char, 1)
-}
+import "unistd.h" as stdio
 
 struct File {
     fd: i32 = -1
@@ -45,7 +14,7 @@ struct File {
         if (fd == -1)
             return null
 
-        var bytes = C.read(fd, data, size);
+        var bytes = stdio.read(fd, data, size);
         if (bytes == -1)
             return null
 
@@ -56,10 +25,10 @@ struct File {
         if (fd == -1)
             return null
 
-        if (C.lseek(fd, off, C.SEEK_SET) == -1)
+        if (stdio.lseek(fd, off, SEEK_SET!) == -1)
             return null
 
-        var bytes = C.read(fd, data, size);
+        var bytes = stdio.read(fd, data, size);
         if (bytes == -1)
             return null
 
@@ -70,8 +39,5 @@ struct File {
     func `!!`() => fd != -1
 
     @inline
-    func seek(off: u64, whence: i32 = C.SEEK_SET) => C.lseek(fd, off:i64, whence)
-
-    const func `str`(sb: StringBuilder) => {}
-    const func `hash`() => fd
+    func seek(off: u64, whence: i32 = SEEK_SET!) => stdio.lseek(fd, off:i64, whence)
 }

--- a/tests/add.h
+++ b/tests/add.h
@@ -1,0 +1,13 @@
+//
+// Created by Carter Mbotho on 2024-04-26.
+//
+
+#include "sub.h"
+
+struct Hello {
+    int age;
+};
+
+#define HELLO_WORLD 100
+
+int add(int a, int b);

--- a/tests/hello.cxy
+++ b/tests/hello.cxy
@@ -1,7 +1,6 @@
-import { Vector } from "stdlib/vector.cxy"
+import "add.h" as Add
+import "stdio.h" as stdio
 
 pub func main() {
-    var x = Vector[i64]();
-    100 + 100;
-    100 + 200;
+    println(HELLO_WORLD!)
 }

--- a/tests/lang/closure.expected.dump
+++ b/tests/lang/closure.expected.dump
@@ -15,117 +15,129 @@ func closureArg2(fn: (&void, func(_: &void, msg: string) -> void)) {
   closureArg1("hello", fn)
 }
 
-struct __Optional12 {
-  - ok: bool = false
-  - val: (string, i32)
+struct __Optional11 {
+  ok: bool = false
+  val: (string, i32)
 }
 
-pub func __Optional12_op__init(this: &__Optional[(string, i32)]) {
+pub func __Optional11_op__init(this: &__Optional[(string, i32)]) {
   this.ok = false
 }
 
-pub func __Optional12_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
+pub func __Optional11_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
   this.val = value
   this.ok = true
 }
 
-pub func __Optional12_op__truthy(this: &__Optional[(string, i32)]): bool {
+pub func __Optional11_op__truthy(this: &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional12_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional11_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func __Optional12_op__truthy(this: const &__Optional[(string, i32)]): bool {
+pub func __Optional11_op__truthy(this: const &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional12_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional11_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func Some13(value: (string, i32)): __Optional[(string, i32)] {
-  var s14 = __Optional12{ok = false, val = (null, 0)}
-  __Optional12_op__init(&s14, value)
-  return s14
+pub func Some12(value: (string, i32)): __Optional[(string, i32)] {
+  return __Optional11{ok = true, val = value}
 }
 
-pub func None15(): __Optional[(string, i32)] {
-  var s16 = __Optional12{ok = false, val = (null, 0)}
-  __Optional12_op__init(&s16)
-  return s16
+pub func __construct114(...args: ()): __Optional[(string, i32)] {
+  var obj: __Optional[(string, i32)]
+  {
+    obj.ok = false
+  }
+  __Optional11_op__init(&obj)
+  return obj
 }
 
-struct __Closure17 {
+pub func None13(): __Optional[(string, i32)] {
+  return __construct114(())
+}
+
+struct __Closure15 {
   - i: i32
   - len: u64
   - data: &string
 }
 
-pub func __Closure17_op__call(this: &__Closure17): __Optional12 {
+pub func __Closure15_op__call(this: &__Closure15): __Optional11 {
   if (this.i < this.len) {
-    return Some13((this.data.[this.i], this.i++))
+    return Some12((this.data.[this.i], this.i++))
   }
-  return None15()
+  return None13()
 }
 
 pub extern func hash_fnv1a_string(h: Hash, str: string): u32
 
-pub func hash18(val: string, init: Hash = 16777619): Hash {
+pub func hash16(val: string, init: Hash = 16777619): Hash {
   return hash_fnv1a_string(init, val)
 }
 
 pub extern func CString_op__init(this: &CString, s: string)
 
+pub func __construct118(...args: (const string)): CString {
+  var obj: struct CString
+  {
+    obj.s = null
+  }
+  CString_op__init(&obj, args.0)
+  return obj
+}
+
 pub extern func OutputStream_appendString(this: OutputStream, s: CString): void
 
-pub func OutputStream_op__lshift19(this: OutputStream, val: string): OutputStream {
-  var s20 = CString{s = null}
-  CString_op__init(&s20, val)
-  OutputStream_appendString(this, s20)
+pub func OutputStream_op__lshift17(this: OutputStream, val: string): OutputStream {
+  OutputStream_appendString(this, __construct118((val)))
   return this
 }
 
-pub struct Slice11 {
+pub struct Slice10 {
   - data: &string
   - len: u64
 }
 
-pub func Slice11_op__init(this: &Slice[string], data: &string, len: u64) {
+pub func Slice10_op__init(this: &Slice[string], data: &string, len: u64) {
   this.data = data
   this.len = len
 }
 
 pub extern func __cxy_assert(cond: bool, file: string, line: u64, column: u64)
 
-pub func Slice11_op__idx_assign(this: &Slice[string], index: i64, data: string) {
+pub func Slice10_op__idx_assign(this: &Slice[string], index: i64, data: string) {
   __cxy_assert(index < this.len, "__builtins.cxy", 559, 9)
   this.data.[index] = data
 }
 
-pub func Slice11_op__idx(this: &Slice[string], index: i64): string {
+pub func Slice10_op__idx(this: &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 565, 9)
   return this.data.[index]
 }
 
-pub func Slice11_op__idx(this: const &Slice[string], index: i64): string {
+pub func Slice10_op__idx(this: const &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 571, 9)
   return this.data.[index]
 }
 
-pub func Slice11_op__range(this: const &Slice[string]): __Closure17 {
+pub func Slice10_op__range(this: const &Slice[string]): __Closure15 {
   var i: i32 = 0
-  return __Closure17{i = i, len = this.len, data = this.data}
+  return __Closure15{i = i, len = this.len, data = this.data}
 }
 
-pub func Slice11_op__hash(this: const &Slice[string]): u32 {
+pub func Slice10_op__hash(this: const &Slice[string]): u32 {
   var code: u32 = 16777619
   {
     const i = 0
     while (i != this.len)
     {
-      code = hash18(this.data.[i], code)
+      code = hash16(this.data.[i], code)
     }
   }
   return code
@@ -135,7 +147,7 @@ pub extern func OutputStream_appendChar(this: OutputStream, ch: wchar)
 
 pub extern func OutputStream_appendString(this: OutputStream, s: string): void
 
-pub func Slice11_op__str(this: const &Slice[string], sb: OutputStream) {
+pub func Slice10_op__str(this: const &Slice[string], sb: OutputStream) {
   OutputStream_appendChar(sb, '[')
   {
     const i = 0
@@ -144,21 +156,21 @@ pub func Slice11_op__str(this: const &Slice[string], sb: OutputStream) {
       if (i != 0) {
         OutputStream_appendString(sb, ", ")
       }
-      OutputStream_op__lshift19(sb, this.data.[i])
+      OutputStream_op__lshift17(sb, this.data.[i])
     }
   }
   OutputStream_appendChar(sb, ']')
 }
 
-struct __Closure21{ }
+struct __Closure19{ }
 
-pub func __Closure21_op__call(this: &__Closure21): i8 {
+pub func __Closure19_op__call(this: &__Closure19): i8 {
   return 1
 }
 
 pub extern func String_op__deinit(this: String)
 
-func __deinit_fwd24(ptr: sptr) {
+func __deinit_fwd21(ptr: sptr) {
   var obj = ((ptr : &class String))
   String_op__deinit(obj)
 }
@@ -166,76 +178,71 @@ func __deinit_fwd24(ptr: sptr) {
 extern func __smart_ptr_alloc(size: u64, dctor: func(ptr: sptr) -> void = null): &void
 
 
-pub func allocate23(len: u32 = 0): String {
-  var obj = ((__smart_ptr_alloc(__bc(0, #String), __deinit_fwd24) : class String))
+pub extern func String_op__init(this: String)
+
+pub func __construct020(...args: ()): String {
+  var obj = ((__smart_ptr_alloc(__bc(0, #String), __deinit_fwd21) : class String))
   {
     obj.vtable = &String_vTable
     obj._capacity = 0
     obj._size = 0
     obj._data = null
   }
+  String_op__init(obj)
   return obj
+}
+
+struct __Closure22{ }
+
+pub func __Closure22_op__call(this: &__Closure22, name: string): String {
+  var sb7 = __construct020(())
+  return sb7
+}
+
+struct __Closure23{ }
+
+pub func __Closure23_op__call(this: &__Closure23): String {
+  var sb8 = __construct020(())
+  return sb8
+}
+
+struct __Closure24{ }
+
+pub func __Closure24_op__call(this: &__Closure24): String {
+  var sb9 = __construct020(())
+  return sb9
 }
 
 struct __Closure25{ }
 
-pub extern func String_op__init(this: String)
-
-pub func __Closure25_op__call(this: &__Closure25, name: string): String {
-  var s22 = allocate23(<u32>0)
-  String_op__init(s22)
-  var sb8 = s22
-  return sb8
+pub func __Closure25_op__call(this: &__Closure25) {
+  const g = __Closure24{}
 }
+
+struct __Closure26{ }
+
+pub func __Closure26_op__call(this: &__Closure26) { }
+
+
+func __Closure26__fwd(ptr: &void): void => __Closure26_op__call(<&__Closure26>ptr)
 
 struct __Closure27{ }
 
-pub func __Closure27_op__call(this: &__Closure27): String {
-  var s26 = allocate23(<u32>0)
-  String_op__init(s26)
-  var sb9 = s26
-  return sb9
-}
-
-struct __Closure29{ }
-
-pub func __Closure29_op__call(this: &__Closure29): String {
-  var s28 = allocate23(<u32>0)
-  String_op__init(s28)
-  var sb10 = s28
-  return sb10
-}
-
-struct __Closure30{ }
-
-pub func __Closure30_op__call(this: &__Closure30) {
-  const g = __Closure29{}
-}
-
-struct __Closure31{ }
-
-pub func __Closure31_op__call(this: &__Closure31) { }
+pub func __Closure27_op__call(this: &__Closure27, msg: string) { }
 
 
-func __Closure31__fwd(ptr: &void): void => __Closure31_op__call(<&__Closure31>ptr)
+func __Closure27__fwd(ptr: &void, msg: string): void => __Closure27_op__call(<&__Closure27>ptr, msg)
 
-struct __Closure32{ }
-
-pub func __Closure32_op__call(this: &__Closure32, msg: string) { }
-
-
-func __Closure32__fwd(ptr: &void, msg: string): void => __Closure32_op__call(<&__Closure32>ptr, msg)
-
-func main(args: Slice11) {
-  const one = __Closure21{}
-  __Closure21_op__call(&one)
-  __Closure25_op__call(&(__Closure25{}), "User")
+func main(args: Slice10) {
+  const one = __Closure19{}
+  __Closure19_op__call(&one)
+  __Closure22_op__call(&(__Closure22{}), "User")
   var x = 100
   var b = "Hello"
-  __Closure27_op__call(&(__Closure27{}))
-  const f = __Closure30{}
-  closureArg0((<&void>&__Closure31{}, __Closure31__fwd))
-  closureArg2((<&void>&__Closure32{}, __Closure32__fwd))
+  __Closure23_op__call(&(__Closure23{}))
+  const f = __Closure25{}
+  closureArg0((<&void>&__Closure26{}, __Closure26__fwd))
+  closureArg2((<&void>&__Closure27{}, __Closure27__fwd))
 }
 
 const llvm.global_ctors = [(0, __init, null)]

--- a/tests/lang/literals.expected.dump
+++ b/tests/lang/literals.expected.dump
@@ -3,117 +3,129 @@ extern func __smart_ptr_get(ptr: sptr): &void
 
 extern func __smart_ptr_drop(ptr: sptr): void
 
-struct __Optional9 {
-  - ok: bool = false
-  - val: (string, i32)
+struct __Optional8 {
+  ok: bool = false
+  val: (string, i32)
 }
 
-pub func __Optional9_op__init(this: &__Optional[(string, i32)]) {
+pub func __Optional8_op__init(this: &__Optional[(string, i32)]) {
   this.ok = false
 }
 
-pub func __Optional9_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
+pub func __Optional8_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
   this.val = value
   this.ok = true
 }
 
-pub func __Optional9_op__truthy(this: &__Optional[(string, i32)]): bool {
+pub func __Optional8_op__truthy(this: &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional9_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional8_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func __Optional9_op__truthy(this: const &__Optional[(string, i32)]): bool {
+pub func __Optional8_op__truthy(this: const &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional9_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional8_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func Some10(value: (string, i32)): __Optional[(string, i32)] {
-  var s11 = __Optional9{ok = false, val = (null, 0)}
-  __Optional9_op__init(&s11, value)
-  return s11
+pub func Some9(value: (string, i32)): __Optional[(string, i32)] {
+  return __Optional8{ok = true, val = value}
 }
 
-pub func None12(): __Optional[(string, i32)] {
-  var s13 = __Optional9{ok = false, val = (null, 0)}
-  __Optional9_op__init(&s13)
-  return s13
+pub func __construct111(...args: ()): __Optional[(string, i32)] {
+  var obj: __Optional[(string, i32)]
+  {
+    obj.ok = false
+  }
+  __Optional8_op__init(&obj)
+  return obj
 }
 
-struct __Closure14 {
+pub func None10(): __Optional[(string, i32)] {
+  return __construct111(())
+}
+
+struct __Closure12 {
   - i: i32
   - len: u64
   - data: &string
 }
 
-pub func __Closure14_op__call(this: &__Closure14): __Optional9 {
+pub func __Closure12_op__call(this: &__Closure12): __Optional8 {
   if (this.i < this.len) {
-    return Some10((this.data.[this.i], this.i++))
+    return Some9((this.data.[this.i], this.i++))
   }
-  return None12()
+  return None10()
 }
 
 pub extern func hash_fnv1a_string(h: Hash, str: string): u32
 
-pub func hash15(val: string, init: Hash = 16777619): Hash {
+pub func hash13(val: string, init: Hash = 16777619): Hash {
   return hash_fnv1a_string(init, val)
 }
 
 pub extern func CString_op__init(this: &CString, s: string)
 
+pub func __construct115(...args: (const string)): CString {
+  var obj: struct CString
+  {
+    obj.s = null
+  }
+  CString_op__init(&obj, args.0)
+  return obj
+}
+
 pub extern func OutputStream_appendString(this: OutputStream, s: CString): void
 
-pub func OutputStream_op__lshift16(this: OutputStream, val: string): OutputStream {
-  var s17 = CString{s = null}
-  CString_op__init(&s17, val)
-  OutputStream_appendString(this, s17)
+pub func OutputStream_op__lshift14(this: OutputStream, val: string): OutputStream {
+  OutputStream_appendString(this, __construct115((val)))
   return this
 }
 
-pub struct Slice8 {
+pub struct Slice7 {
   - data: &string
   - len: u64
 }
 
-pub func Slice8_op__init(this: &Slice[string], data: &string, len: u64) {
+pub func Slice7_op__init(this: &Slice[string], data: &string, len: u64) {
   this.data = data
   this.len = len
 }
 
 pub extern func __cxy_assert(cond: bool, file: string, line: u64, column: u64)
 
-pub func Slice8_op__idx_assign(this: &Slice[string], index: i64, data: string) {
+pub func Slice7_op__idx_assign(this: &Slice[string], index: i64, data: string) {
   __cxy_assert(index < this.len, "__builtins.cxy", 559, 9)
   this.data.[index] = data
 }
 
-pub func Slice8_op__idx(this: &Slice[string], index: i64): string {
+pub func Slice7_op__idx(this: &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 565, 9)
   return this.data.[index]
 }
 
-pub func Slice8_op__idx(this: const &Slice[string], index: i64): string {
+pub func Slice7_op__idx(this: const &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 571, 9)
   return this.data.[index]
 }
 
-pub func Slice8_op__range(this: const &Slice[string]): __Closure14 {
+pub func Slice7_op__range(this: const &Slice[string]): __Closure12 {
   var i: i32 = 0
-  return __Closure14{i = i, len = this.len, data = this.data}
+  return __Closure12{i = i, len = this.len, data = this.data}
 }
 
-pub func Slice8_op__hash(this: const &Slice[string]): u32 {
+pub func Slice7_op__hash(this: const &Slice[string]): u32 {
   var code: u32 = 16777619
   {
     const i = 0
     while (i != this.len)
     {
-      code = hash15(this.data.[i], code)
+      code = hash13(this.data.[i], code)
     }
   }
   return code
@@ -123,7 +135,7 @@ pub extern func OutputStream_appendChar(this: OutputStream, ch: wchar)
 
 pub extern func OutputStream_appendString(this: OutputStream, s: string): void
 
-pub func Slice8_op__str(this: const &Slice[string], sb: OutputStream) {
+pub func Slice7_op__str(this: const &Slice[string], sb: OutputStream) {
   OutputStream_appendChar(sb, '[')
   {
     const i = 0
@@ -132,13 +144,13 @@ pub func Slice8_op__str(this: const &Slice[string], sb: OutputStream) {
       if (i != 0) {
         OutputStream_appendString(sb, ", ")
       }
-      OutputStream_op__lshift16(sb, this.data.[i])
+      OutputStream_op__lshift14(sb, this.data.[i])
     }
   }
   OutputStream_appendChar(sb, ']')
 }
 
-func main(args: Slice8) { }
+func main(args: Slice7) { }
 
 
 const llvm.global_ctors = [(0, __init, null)]

--- a/tests/lang/tuples.expected.dump
+++ b/tests/lang/tuples.expected.dump
@@ -11,117 +11,129 @@ func swap(tup: (string, i32)): (i32, string) {
   return (tup.1, tup.0)
 }
 
-struct __Optional10 {
-  - ok: bool = false
-  - val: (string, i32)
+struct __Optional9 {
+  ok: bool = false
+  val: (string, i32)
 }
 
-pub func __Optional10_op__init(this: &__Optional[(string, i32)]) {
+pub func __Optional9_op__init(this: &__Optional[(string, i32)]) {
   this.ok = false
 }
 
-pub func __Optional10_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
+pub func __Optional9_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
   this.val = value
   this.ok = true
 }
 
-pub func __Optional10_op__truthy(this: &__Optional[(string, i32)]): bool {
+pub func __Optional9_op__truthy(this: &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional10_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional9_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func __Optional10_op__truthy(this: const &__Optional[(string, i32)]): bool {
+pub func __Optional9_op__truthy(this: const &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional10_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional9_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func Some11(value: (string, i32)): __Optional[(string, i32)] {
-  var s12 = __Optional10{ok = false, val = (null, 0)}
-  __Optional10_op__init(&s12, value)
-  return s12
+pub func Some10(value: (string, i32)): __Optional[(string, i32)] {
+  return __Optional9{ok = true, val = value}
 }
 
-pub func None13(): __Optional[(string, i32)] {
-  var s14 = __Optional10{ok = false, val = (null, 0)}
-  __Optional10_op__init(&s14)
-  return s14
+pub func __construct112(...args: ()): __Optional[(string, i32)] {
+  var obj: __Optional[(string, i32)]
+  {
+    obj.ok = false
+  }
+  __Optional9_op__init(&obj)
+  return obj
 }
 
-struct __Closure15 {
+pub func None11(): __Optional[(string, i32)] {
+  return __construct112(())
+}
+
+struct __Closure13 {
   - i: i32
   - len: u64
   - data: &string
 }
 
-pub func __Closure15_op__call(this: &__Closure15): __Optional10 {
+pub func __Closure13_op__call(this: &__Closure13): __Optional9 {
   if (this.i < this.len) {
-    return Some11((this.data.[this.i], this.i++))
+    return Some10((this.data.[this.i], this.i++))
   }
-  return None13()
+  return None11()
 }
 
 pub extern func hash_fnv1a_string(h: Hash, str: string): u32
 
-pub func hash16(val: string, init: Hash = 16777619): Hash {
+pub func hash14(val: string, init: Hash = 16777619): Hash {
   return hash_fnv1a_string(init, val)
 }
 
 pub extern func CString_op__init(this: &CString, s: string)
 
+pub func __construct116(...args: (const string)): CString {
+  var obj: struct CString
+  {
+    obj.s = null
+  }
+  CString_op__init(&obj, args.0)
+  return obj
+}
+
 pub extern func OutputStream_appendString(this: OutputStream, s: CString): void
 
-pub func OutputStream_op__lshift17(this: OutputStream, val: string): OutputStream {
-  var s18 = CString{s = null}
-  CString_op__init(&s18, val)
-  OutputStream_appendString(this, s18)
+pub func OutputStream_op__lshift15(this: OutputStream, val: string): OutputStream {
+  OutputStream_appendString(this, __construct116((val)))
   return this
 }
 
-pub struct Slice9 {
+pub struct Slice8 {
   - data: &string
   - len: u64
 }
 
-pub func Slice9_op__init(this: &Slice[string], data: &string, len: u64) {
+pub func Slice8_op__init(this: &Slice[string], data: &string, len: u64) {
   this.data = data
   this.len = len
 }
 
 pub extern func __cxy_assert(cond: bool, file: string, line: u64, column: u64)
 
-pub func Slice9_op__idx_assign(this: &Slice[string], index: i64, data: string) {
+pub func Slice8_op__idx_assign(this: &Slice[string], index: i64, data: string) {
   __cxy_assert(index < this.len, "__builtins.cxy", 559, 9)
   this.data.[index] = data
 }
 
-pub func Slice9_op__idx(this: &Slice[string], index: i64): string {
+pub func Slice8_op__idx(this: &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 565, 9)
   return this.data.[index]
 }
 
-pub func Slice9_op__idx(this: const &Slice[string], index: i64): string {
+pub func Slice8_op__idx(this: const &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 571, 9)
   return this.data.[index]
 }
 
-pub func Slice9_op__range(this: const &Slice[string]): __Closure15 {
+pub func Slice8_op__range(this: const &Slice[string]): __Closure13 {
   var i: i32 = 0
-  return __Closure15{i = i, len = this.len, data = this.data}
+  return __Closure13{i = i, len = this.len, data = this.data}
 }
 
-pub func Slice9_op__hash(this: const &Slice[string]): u32 {
+pub func Slice8_op__hash(this: const &Slice[string]): u32 {
   var code: u32 = 16777619
   {
     const i = 0
     while (i != this.len)
     {
-      code = hash16(this.data.[i], code)
+      code = hash14(this.data.[i], code)
     }
   }
   return code
@@ -131,7 +143,7 @@ pub extern func OutputStream_appendChar(this: OutputStream, ch: wchar)
 
 pub extern func OutputStream_appendString(this: OutputStream, s: string): void
 
-pub func Slice9_op__str(this: const &Slice[string], sb: OutputStream) {
+pub func Slice8_op__str(this: const &Slice[string], sb: OutputStream) {
   OutputStream_appendChar(sb, '[')
   {
     const i = 0
@@ -140,13 +152,13 @@ pub func Slice9_op__str(this: const &Slice[string], sb: OutputStream) {
       if (i != 0) {
         OutputStream_appendString(sb, ", ")
       }
-      OutputStream_op__lshift17(sb, this.data.[i])
+      OutputStream_op__lshift15(sb, this.data.[i])
     }
   }
   OutputStream_appendChar(sb, ']')
 }
 
-func main(args: Slice9) {
+func main(args: Slice8) {
   var x: (bool, i32) = (true, 10)
   x = (false, 20)
   var y: Tup2 = ('a', (6.000000e-01, "Hello", (true, 'A')))
@@ -157,9 +169,9 @@ func main(args: Slice9) {
   var z: (i32, string) = swap(<(string, i32)>("Hello", 10))
   var f: &(i32, string) = z&
   var k: (string, i32) = (f.1, f.0)
-  var _gi8 = swap(<(string, i32)>("Hello", 10))
-  var num = _gi8.0
-  var str = _gi8.1
+  var _gi7 = swap(<(string, i32)>("Hello", 10))
+  var num = _gi7.0
+  var str = _gi7.1
 }
 
 const llvm.global_ctors = [(0, __init, null)]

--- a/tests/lang/varargs.expected.dump
+++ b/tests/lang/varargs.expected.dump
@@ -3,117 +3,129 @@ extern func __smart_ptr_get(ptr: sptr): &void
 
 extern func __smart_ptr_drop(ptr: sptr): void
 
-struct __Optional9 {
-  - ok: bool = false
-  - val: (string, i32)
+struct __Optional8 {
+  ok: bool = false
+  val: (string, i32)
 }
 
-pub func __Optional9_op__init(this: &__Optional[(string, i32)]) {
+pub func __Optional8_op__init(this: &__Optional[(string, i32)]) {
   this.ok = false
 }
 
-pub func __Optional9_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
+pub func __Optional8_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
   this.val = value
   this.ok = true
 }
 
-pub func __Optional9_op__truthy(this: &__Optional[(string, i32)]): bool {
+pub func __Optional8_op__truthy(this: &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional9_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional8_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func __Optional9_op__truthy(this: const &__Optional[(string, i32)]): bool {
+pub func __Optional8_op__truthy(this: const &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional9_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional8_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func Some10(value: (string, i32)): __Optional[(string, i32)] {
-  var s11 = __Optional9{ok = false, val = (null, 0)}
-  __Optional9_op__init(&s11, value)
-  return s11
+pub func Some9(value: (string, i32)): __Optional[(string, i32)] {
+  return __Optional8{ok = true, val = value}
 }
 
-pub func None12(): __Optional[(string, i32)] {
-  var s13 = __Optional9{ok = false, val = (null, 0)}
-  __Optional9_op__init(&s13)
-  return s13
+pub func __construct111(...args: ()): __Optional[(string, i32)] {
+  var obj: __Optional[(string, i32)]
+  {
+    obj.ok = false
+  }
+  __Optional8_op__init(&obj)
+  return obj
 }
 
-struct __Closure14 {
+pub func None10(): __Optional[(string, i32)] {
+  return __construct111(())
+}
+
+struct __Closure12 {
   - i: i32
   - len: u64
   - data: &string
 }
 
-pub func __Closure14_op__call(this: &__Closure14): __Optional9 {
+pub func __Closure12_op__call(this: &__Closure12): __Optional8 {
   if (this.i < this.len) {
-    return Some10((this.data.[this.i], this.i++))
+    return Some9((this.data.[this.i], this.i++))
   }
-  return None12()
+  return None10()
 }
 
 pub extern func hash_fnv1a_string(h: Hash, str: string): u32
 
-pub func hash15(val: string, init: Hash = 16777619): Hash {
+pub func hash13(val: string, init: Hash = 16777619): Hash {
   return hash_fnv1a_string(init, val)
 }
 
 pub extern func CString_op__init(this: &CString, s: string)
 
+pub func __construct115(...args: (const string)): CString {
+  var obj: struct CString
+  {
+    obj.s = null
+  }
+  CString_op__init(&obj, args.0)
+  return obj
+}
+
 pub extern func OutputStream_appendString(this: OutputStream, s: CString): void
 
-pub func OutputStream_op__lshift16(this: OutputStream, val: string): OutputStream {
-  var s17 = CString{s = null}
-  CString_op__init(&s17, val)
-  OutputStream_appendString(this, s17)
+pub func OutputStream_op__lshift14(this: OutputStream, val: string): OutputStream {
+  OutputStream_appendString(this, __construct115((val)))
   return this
 }
 
-pub struct Slice8 {
+pub struct Slice7 {
   - data: &string
   - len: u64
 }
 
-pub func Slice8_op__init(this: &Slice[string], data: &string, len: u64) {
+pub func Slice7_op__init(this: &Slice[string], data: &string, len: u64) {
   this.data = data
   this.len = len
 }
 
 pub extern func __cxy_assert(cond: bool, file: string, line: u64, column: u64)
 
-pub func Slice8_op__idx_assign(this: &Slice[string], index: i64, data: string) {
+pub func Slice7_op__idx_assign(this: &Slice[string], index: i64, data: string) {
   __cxy_assert(index < this.len, "__builtins.cxy", 559, 9)
   this.data.[index] = data
 }
 
-pub func Slice8_op__idx(this: &Slice[string], index: i64): string {
+pub func Slice7_op__idx(this: &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 565, 9)
   return this.data.[index]
 }
 
-pub func Slice8_op__idx(this: const &Slice[string], index: i64): string {
+pub func Slice7_op__idx(this: const &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 571, 9)
   return this.data.[index]
 }
 
-pub func Slice8_op__range(this: const &Slice[string]): __Closure14 {
+pub func Slice7_op__range(this: const &Slice[string]): __Closure12 {
   var i: i32 = 0
-  return __Closure14{i = i, len = this.len, data = this.data}
+  return __Closure12{i = i, len = this.len, data = this.data}
 }
 
-pub func Slice8_op__hash(this: const &Slice[string]): u32 {
+pub func Slice7_op__hash(this: const &Slice[string]): u32 {
   var code: u32 = 16777619
   {
     const i = 0
     while (i != this.len)
     {
-      code = hash15(this.data.[i], code)
+      code = hash13(this.data.[i], code)
     }
   }
   return code
@@ -123,7 +135,7 @@ pub extern func OutputStream_appendChar(this: OutputStream, ch: wchar)
 
 pub extern func OutputStream_appendString(this: OutputStream, s: string): void
 
-pub func Slice8_op__str(this: const &Slice[string], sb: OutputStream) {
+pub func Slice7_op__str(this: const &Slice[string], sb: OutputStream) {
   OutputStream_appendChar(sb, '[')
   {
     const i = 0
@@ -132,29 +144,29 @@ pub func Slice8_op__str(this: const &Slice[string], sb: OutputStream) {
       if (i != 0) {
         OutputStream_appendString(sb, ", ")
       }
-      OutputStream_op__lshift16(sb, this.data.[i])
+      OutputStream_op__lshift14(sb, this.data.[i])
     }
   }
   OutputStream_appendChar(sb, ']')
 }
 
-func varargs18(...args: (i8, string, wchar, f64)) { }
+func varargs16(...args: (i8, string, wchar, f64)) { }
 
 
-func add20(...nums: (f32, f64, f64)) {
+func add18(...nums: (f32, f64, f64)) {
   var sum: f32 = 0
   sum += nums.0
   sum += nums.1
   sum += nums.2
 }
 
-func many19(x: i32, ...rest: (f64, f64)) {
-  add20((<f32>x, rest.0, rest.1))
+func many17(x: i32, ...rest: (f64, f64)) {
+  add18((<f32>x, rest.0, rest.1))
 }
 
-func main(args: Slice8) {
-  varargs18((10, "Hello", 'c', 2.000600e+03))
-  many19(<i32>10, (1.000000e+01, 1.006000e+02))
+func main(args: Slice7) {
+  varargs16((10, "Hello", 'c', 2.000600e+03))
+  many17(<i32>10, (1.000000e+01, 1.006000e+02))
 }
 
 const llvm.global_ctors = [(0, __init, null)]

--- a/tests/lang/variables.expected.dump
+++ b/tests/lang/variables.expected.dump
@@ -5,117 +5,129 @@ extern func __smart_ptr_drop(ptr: sptr): void
 
 var X = 10
 const Y = ("Hello", "World")
-struct __Optional10 {
-  - ok: bool = false
-  - val: (string, i32)
+struct __Optional9 {
+  ok: bool = false
+  val: (string, i32)
 }
 
-pub func __Optional10_op__init(this: &__Optional[(string, i32)]) {
+pub func __Optional9_op__init(this: &__Optional[(string, i32)]) {
   this.ok = false
 }
 
-pub func __Optional10_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
+pub func __Optional9_op__init(this: &__Optional[(string, i32)], value: (string, i32)) {
   this.val = value
   this.ok = true
 }
 
-pub func __Optional10_op__truthy(this: &__Optional[(string, i32)]): bool {
+pub func __Optional9_op__truthy(this: &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional10_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional9_op__deref(this: &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func __Optional10_op__truthy(this: const &__Optional[(string, i32)]): bool {
+pub func __Optional9_op__truthy(this: const &__Optional[(string, i32)]): bool {
   return this.ok
 }
 
-pub func __Optional10_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
+pub func __Optional9_op__deref(this: const &__Optional[(string, i32)]): (string, i32) {
   return this.val
 }
 
-pub func Some11(value: (string, i32)): __Optional[(string, i32)] {
-  var s12 = __Optional10{ok = false, val = (null, 0)}
-  __Optional10_op__init(&s12, value)
-  return s12
+pub func Some10(value: (string, i32)): __Optional[(string, i32)] {
+  return __Optional9{ok = true, val = value}
 }
 
-pub func None13(): __Optional[(string, i32)] {
-  var s14 = __Optional10{ok = false, val = (null, 0)}
-  __Optional10_op__init(&s14)
-  return s14
+pub func __construct112(...args: ()): __Optional[(string, i32)] {
+  var obj: __Optional[(string, i32)]
+  {
+    obj.ok = false
+  }
+  __Optional9_op__init(&obj)
+  return obj
 }
 
-struct __Closure15 {
+pub func None11(): __Optional[(string, i32)] {
+  return __construct112(())
+}
+
+struct __Closure13 {
   - i: i32
   - len: u64
   - data: &string
 }
 
-pub func __Closure15_op__call(this: &__Closure15): __Optional10 {
+pub func __Closure13_op__call(this: &__Closure13): __Optional9 {
   if (this.i < this.len) {
-    return Some11((this.data.[this.i], this.i++))
+    return Some10((this.data.[this.i], this.i++))
   }
-  return None13()
+  return None11()
 }
 
 pub extern func hash_fnv1a_string(h: Hash, str: string): u32
 
-pub func hash16(val: string, init: Hash = 16777619): Hash {
+pub func hash14(val: string, init: Hash = 16777619): Hash {
   return hash_fnv1a_string(init, val)
 }
 
 pub extern func CString_op__init(this: &CString, s: string)
 
+pub func __construct116(...args: (const string)): CString {
+  var obj: struct CString
+  {
+    obj.s = null
+  }
+  CString_op__init(&obj, args.0)
+  return obj
+}
+
 pub extern func OutputStream_appendString(this: OutputStream, s: CString): void
 
-pub func OutputStream_op__lshift17(this: OutputStream, val: string): OutputStream {
-  var s18 = CString{s = null}
-  CString_op__init(&s18, val)
-  OutputStream_appendString(this, s18)
+pub func OutputStream_op__lshift15(this: OutputStream, val: string): OutputStream {
+  OutputStream_appendString(this, __construct116((val)))
   return this
 }
 
-pub struct Slice9 {
+pub struct Slice8 {
   - data: &string
   - len: u64
 }
 
-pub func Slice9_op__init(this: &Slice[string], data: &string, len: u64) {
+pub func Slice8_op__init(this: &Slice[string], data: &string, len: u64) {
   this.data = data
   this.len = len
 }
 
 pub extern func __cxy_assert(cond: bool, file: string, line: u64, column: u64)
 
-pub func Slice9_op__idx_assign(this: &Slice[string], index: i64, data: string) {
+pub func Slice8_op__idx_assign(this: &Slice[string], index: i64, data: string) {
   __cxy_assert(index < this.len, "__builtins.cxy", 559, 9)
   this.data.[index] = data
 }
 
-pub func Slice9_op__idx(this: &Slice[string], index: i64): string {
+pub func Slice8_op__idx(this: &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 565, 9)
   return this.data.[index]
 }
 
-pub func Slice9_op__idx(this: const &Slice[string], index: i64): string {
+pub func Slice8_op__idx(this: const &Slice[string], index: i64): string {
   __cxy_assert(index < this.len, "__builtins.cxy", 571, 9)
   return this.data.[index]
 }
 
-pub func Slice9_op__range(this: const &Slice[string]): __Closure15 {
+pub func Slice8_op__range(this: const &Slice[string]): __Closure13 {
   var i: i32 = 0
-  return __Closure15{i = i, len = this.len, data = this.data}
+  return __Closure13{i = i, len = this.len, data = this.data}
 }
 
-pub func Slice9_op__hash(this: const &Slice[string]): u32 {
+pub func Slice8_op__hash(this: const &Slice[string]): u32 {
   var code: u32 = 16777619
   {
     const i = 0
     while (i != this.len)
     {
-      code = hash16(this.data.[i], code)
+      code = hash14(this.data.[i], code)
     }
   }
   return code
@@ -125,7 +137,7 @@ pub extern func OutputStream_appendChar(this: OutputStream, ch: wchar)
 
 pub extern func OutputStream_appendString(this: OutputStream, s: string): void
 
-pub func Slice9_op__str(this: const &Slice[string], sb: OutputStream) {
+pub func Slice8_op__str(this: const &Slice[string], sb: OutputStream) {
   OutputStream_appendChar(sb, '[')
   {
     const i = 0
@@ -134,19 +146,19 @@ pub func Slice9_op__str(this: const &Slice[string], sb: OutputStream) {
       if (i != 0) {
         OutputStream_appendString(sb, ", ")
       }
-      OutputStream_op__lshift17(sb, this.data.[i])
+      OutputStream_op__lshift15(sb, this.data.[i])
     }
   }
   OutputStream_appendChar(sb, ']')
 }
 
-struct __Closure19{ }
+struct __Closure17{ }
 
-pub func __Closure19_op__call(this: &__Closure19): (i8, i8) {
+pub func __Closure17_op__call(this: &__Closure17): (i8, i8) {
   return (20, 20)
 }
 
-func main(args: Slice9) {
+func main(args: Slice8) {
   var x
   var y = 10
   const k = y
@@ -168,9 +180,9 @@ func main(args: Slice9) {
     var b = true
     var d = 20
     var e = ' '
-    var _gi8 = __Closure19_op__call(&(__Closure19{}))
-    var f = _gi8.0
-    var g = _gi8.1
+    var _gi7 = __Closure17_op__call(&(__Closure17{}))
+    var f = _gi7.0
+    var g = _gi7.1
   }
 }
 

--- a/tests/sub.h
+++ b/tests/sub.h
@@ -1,0 +1,7 @@
+//
+// Created by Carter Mbotho on 2024-04-27.
+//
+
+#define SUB 100
+
+int sub(int a, int b);


### PR DESCRIPTION
This feature would allow seamless integration with C.

```c
import "stdio.h" as stdio

func hello() => stdio.printf("Hello World")

```