### PR TITLE
Adding support for debug information

### DIFF
--- a/examples/hello.cxy
+++ b/examples/hello.cxy
@@ -1,14 +1,13 @@
-import "add.h" as Add
-import "stdio.h" as stdio
 
-struct Say[T] {
-    func say[U](t: T, u: U) {
-        println(t, u)
-    }
+@pure
+func say(fn: func(msg: string) -> void) {
+    fn("Hell World")
+}
+
+func sayer(msg: string) {
+    println("You said ", msg)
 }
 
 pub func main() {
-    var x = Say[i32]{};
-    info!("{t}", typeof!(x))
-    x.say(10, "Hello")
+    say(sayer)
 }

--- a/src/cxy/driver/options.c
+++ b/src/cxy/driver/options.c
@@ -373,7 +373,10 @@ bool parseCommandLineOptions(
         Use(cmdArrayArgument,
             Name("c-lib"),
             Help("Adds library to link against"),
-            Def("[]")));
+            Def("[]")),
+        Opt(Sf('g'),
+            Name("debug"),
+            Help("Produce debug information for the program")));
 
     int selected = argparse(argc, &argv, parser);
 
@@ -421,6 +424,7 @@ bool parseCommandLineOptions(
     moveListOptions(&options->importSearchPaths, &getGlobalArray(cmd, 11));
     moveListOptions(&options->librarySearchPaths, &getGlobalArray(cmd, 12));
     moveListOptions(&options->libraries, &getGlobalArray(cmd, 13));
+    options->debug = getGlobalBool(cmd, 14);
 
     file_count = *argc - 1;
 

--- a/src/cxy/driver/options.h
+++ b/src/cxy/driver/options.h
@@ -58,6 +58,7 @@ typedef struct Options {
     bool withoutBuiltins;
     bool noPIE;
     bool withMemoryManager;
+    bool debug;
     OptimizationLevel optimizationLevel;
     struct {
         bool printIR;

--- a/src/cxy/lang/backend/llvm/array.cpp
+++ b/src/cxy/lang/backend/llvm/array.cpp
@@ -12,6 +12,7 @@ static llvm::Constant *makeArrayLiteral(cxy::LLVMContext &ctx, AstNode *node)
     auto elem = node->arrayExpr.elements;
     auto elementType = ctx.getLLVMType(node->type->array.elementType);
     for (; elem; elem = elem->next) {
+        ctx.emitDebugLocation(elem);
         if (isIntegerType(elem->type)) {
             elements.push_back(
                 llvm::ConstantInt::get(elementType,
@@ -47,6 +48,7 @@ void generateArrayExpr(AstVisitor *visitor, AstNode *node)
 {
     auto &ctx = cxy::LLVMContext::from(visitor);
     auto array = ctx.createUndefined(node->type);
+    ctx.emitDebugLocation(node);
 
     auto elem = node->arrayExpr.elements;
     for (u64 i = 0; elem; elem = elem->next, i++) {

--- a/src/cxy/lang/backend/llvm/binary.cpp
+++ b/src/cxy/lang/backend/llvm/binary.cpp
@@ -15,6 +15,7 @@
 static void generateLogicAndOr(AstVisitor *visitor, AstNode *node)
 {
     auto &ctx = cxy::LLVMContext::from(visitor);
+    ctx.emitDebugLocation(node);
 
     auto &builder = ctx.builder;
     auto func = builder.GetInsertBlock()->getParent();
@@ -77,6 +78,8 @@ void generateBinaryExpr(AstVisitor *visitor, AstNode *node)
     }
 
     auto &ctx = cxy::LLVMContext::from(visitor);
+    ctx.emitDebugLocation(node);
+
     AstNode *left = node->binaryExpr.lhs, *right = node->binaryExpr.rhs;
     const Type *type = node->type;
 

--- a/src/cxy/lang/backend/llvm/context.h
+++ b/src/cxy/lang/backend/llvm/context.h
@@ -33,6 +33,8 @@ public:
 #undef DEFINE_STACK_VAR
 };
 
+class DebugContext;
+
 struct LLVMContext {
     bool unreachable{false};
     Log *L{nullptr};
@@ -48,6 +50,8 @@ struct LLVMContext {
                          llvm::TargetMachine *TM);
 
     inline llvm::Module &module() { return *_module; }
+
+    inline DebugContext *debugCtx() { return _debugCtx.get(); }
 
     inline void returnValue(llvm::Value *value) { _value = value; }
     inline llvm::Value *value() { return _value; }
@@ -97,6 +101,9 @@ struct LLVMContext {
     llvm::Type *createStructType(const Type *type);
     llvm::Type *createInterfaceType(const Type *type);
 
+    llvm::Value *withDebugLoc(const AstNode *node, llvm::Value *value);
+    void emitDebugLocation(const AstNode *node);
+
 private:
     llvm::Type *createTupleType(const Type *type);
     llvm::Type *createFunctionType(const Type *type);
@@ -115,6 +122,7 @@ private:
     llvm::Value *_value = {nullptr};
     Stack _stack{};
     const char *_sourceFilename{nullptr};
+    std::unique_ptr<DebugContext> _debugCtx{nullptr};
 };
 
 llvm::Value *codegen(AstVisitor *visitor, AstNode *node);

--- a/src/cxy/lang/backend/llvm/debug.cpp
+++ b/src/cxy/lang/backend/llvm/debug.cpp
@@ -3,3 +3,553 @@
 //
 
 #include "debug.h"
+#include "context.h"
+#include "llvm.h"
+
+#include <lang/frontend/flag.h>
+#include <lang/frontend/ttable.h>
+
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Path.h>
+
+namespace cxy {
+
+DebugContext::DebugContext(llvm::Module &module,
+                           CompilerDriver *driver,
+                           cstring fileName)
+    : builder(module), module{module}, types{driver->types}
+{
+    llvm::SmallString<128> path(fileName);
+    llvm::sys::fs::make_absolute(path);
+
+    llvm::DIFile *diFile =
+        builder.createFile(path, llvm::sys::path::parent_path(path));
+    bool isOptimized = driver->options.optimizationLevel > O0;
+    auto emissionKind = llvm::DICompileUnit::DebugEmissionKind::FullDebug;
+    compileUnit =
+        builder.createCompileUnit(llvm::dwarf::DW_LANG_C,
+                                  diFile,
+                                  "cxy-v" CXY_VERSION_STR /* Producer */,
+                                  isOptimized,
+                                  llvm::StringRef(),
+                                  0 /* RV */,
+                                  llvm::StringRef(),
+                                  emissionKind);
+
+    module.addModuleFlag(llvm::Module::Warning, "Dwarf Version", 2);
+
+    module.addModuleFlag(llvm::Module::Error,
+                         "Debug Info Version",
+                         llvm::DEBUG_METADATA_VERSION);
+}
+
+llvm::DIType *DebugContext::getDIType(const Type *type)
+{
+    type = unwrapType(type, nullptr);
+    csAssert0(type != nullptr);
+
+    return static_cast<llvm::DIType *>(
+        type->dbg ?: updateDebug(type, convertToDIType(type)));
+}
+
+llvm::Type *getLLVMType(const Type *type)
+{
+    csAssert0(type->codegen);
+    return static_cast<llvm::Type *>(type->codegen);
+}
+
+llvm::DIType *DebugContext::convertToDIType(const Type *type)
+{
+    switch (type->tag) {
+    case typPrimitive:
+        unreachable("Already converted in constructor");
+        break;
+    case typVoid:
+        return llvm::DIBasicType::get(
+            module.getContext(), llvm::dwarf::DW_TAG_base_type, type->name, 0);
+    case typString:
+        return builder.createPointerType(
+            getDIType(getPrimitiveType(types, prtChar)),
+            module.getDataLayout()
+                    .getABITypeAlign(getLLVMType(types->stringType))
+                    .value() *
+                8);
+    case typEnum:
+        return createEnumType(type);
+    case typPointer:
+        return pointerToDIType(type);
+    case typArray:
+        return arrayToDIType(type);
+    case typThis:
+        return getDIType(type->_this.that);
+    case typTuple:
+        return createTupleType(type);
+    case typFunc:
+        return createFunctionType(type);
+    case typUnion:
+        return createUnionType(type);
+    case typClass:
+        return createClassType(type);
+    case typStruct:
+        return createStructType(type);
+    default:
+        return nullptr;
+    }
+}
+
+llvm::DIType *DebugContext::pointerToDIType(const Type *type)
+{
+    return builder.createPointerType(
+        getDIType(type->pointer.pointed),
+        module.getDataLayout().getPointerSizeInBits());
+}
+
+llvm::DIType *DebugContext::arrayToDIType(const Type *type)
+{
+    llvm::SmallVector<llvm::Metadata *, 4> subscripts;
+    subscripts.push_back(builder.getOrCreateSubrange(0, (i64)type->array.len));
+    return builder.createArrayType(
+        type->array.len,
+        8 * module.getDataLayout()
+                .getABITypeAlign((llvm::Type *)type->codegen)
+                .value(),
+        getDIType(type->array.elementType),
+        builder.getOrCreateArray(subscripts));
+}
+
+llvm::DIType *DebugContext::createStructType(const Type *type)
+{
+    auto &layout = module.getDataLayout();
+    auto structLayout = layout.getStructLayout(
+        llvm::dyn_cast_or_null<llvm::StructType>(getLLVMType(type)));
+    auto decl = type->tStruct.decl;
+
+    auto diStructType = builder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_structure_type,
+        type->name,
+        currentScope(),
+        compileUnit->getFile(),
+        decl->loc.begin.row);
+    updateDebug(type, diStructType);
+
+    std::vector<llvm::Metadata *> membersMetadata;
+    addFields(membersMetadata, *structLayout, *type->tStruct.members);
+
+    auto members = builder.getOrCreateArray(membersMetadata);
+    auto ret =
+        builder.createStructType(currentScope(),
+                                 type->name,
+                                 compileUnit->getFile(),
+                                 type->tStruct.decl->loc.begin.row,
+                                 structLayout->getSizeInBits(),
+                                 structLayout->getAlignment().value() * 8,
+                                 llvm::DINode::FlagZero,
+                                 nullptr,
+                                 members);
+
+    return builder.replaceTemporary(llvm::TempMDNode(diStructType), ret);
+}
+
+llvm::DIType *DebugContext::createClassType(const Type *type)
+{
+    auto &layout = module.getDataLayout();
+    auto decl = type->tClass.decl;
+    auto classLayout =
+        layout.getStructLayout(llvm::dyn_cast_or_null<llvm::StructType>(
+            static_cast<llvm::Type *>(decl->codegen)));
+
+    llvm::DIType *derivedFrom = nullptr;
+    auto diClassType = builder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_structure_type,
+        type->name,
+        currentScope(),
+        compileUnit->getFile(),
+        decl->loc.begin.row);
+    updateDebug(type, diClassType);
+
+    std::vector<llvm::Metadata *> membersMetadata;
+    if (type->tClass.inheritance->base) {
+        derivedFrom = getDIType(type->tClass.inheritance->base);
+        auto fwd =
+            builder.createClassType(currentScope(),
+                                    type->name,
+                                    compileUnit->getFile(),
+                                    decl->loc.begin.row,
+                                    classLayout->getSizeInBits(),
+                                    classLayout->getAlignment().value() * 8,
+                                    0 /* OffsetInBits */,
+                                    llvm::DINode::FlagFwdDecl,
+                                    nullptr /* DerivedFrom */,
+                                    nullptr /* Elements */,
+                                    0 /* RunTimeLang */,
+                                    nullptr /* VTableHolder */,
+                                    nullptr /* TemplateParms */,
+                                    llvm::StringRef() /* UniqueIdentifier */);
+        auto dt = builder.createInheritance(fwd,
+                                            derivedFrom,
+                                            0 /* BaseOffset */,
+                                            0 /* VBPtrOffset */,
+                                            llvm::DINode::FlagPublic);
+        membersMetadata.push_back(dt);
+    }
+    addFields(membersMetadata, *classLayout, *type->tClass.members);
+
+    auto ret =
+        builder.createClassType(currentScope(),
+                                type->name,
+                                compileUnit->getFile(),
+                                decl->loc.begin.row,
+                                classLayout->getSizeInBits(),
+                                classLayout->getAlignment().value() * 8,
+                                0 /* OffsetInBits */,
+                                llvm::DINode::FlagZero,
+                                derivedFrom,
+                                builder.getOrCreateArray(membersMetadata),
+                                0 /* RunTimeLang */,
+                                nullptr /* VTableHolder  */,
+                                nullptr /* TemplateParms */,
+                                llvm::StringRef() /* UniqueIdentifier */);
+
+    return builder.replaceTemporary(llvm::TempMDNode(diClassType), ret);
+}
+
+llvm::DIType *DebugContext::createTupleType(const Type *type)
+{
+    auto &layout = module.getDataLayout();
+    auto llvmType = getLLVMType(type);
+    auto structLayout = layout.getStructLayout(
+        llvm::dyn_cast_or_null<llvm::StructType>(llvmType));
+    std::vector<llvm::Metadata *> membersMetadata;
+    for (u64 i = 0; i < type->tuple.count; i++) {
+        auto member = type->tuple.members[i];
+        auto diType = getDIType(member);
+        auto diTypeSize = diType->getSizeInBits();
+        auto elLlvmType = getLLVMType(member);
+        auto alignment = layout
+                             .getABITypeAlign(typeIs(member, Func)
+                                                  ? elLlvmType->getPointerTo()
+                                                  : elLlvmType)
+                             .value() *
+                         8;
+
+        membersMetadata.push_back(
+            builder.createMemberType(currentScope(),
+                                     std::to_string(i),
+                                     compileUnit->getFile(),
+                                     1 /* LineNo */,
+                                     diTypeSize,
+                                     alignment,
+                                     structLayout->getElementOffsetInBits(i),
+                                     llvm::DINode::FlagZero,
+                                     diType));
+    }
+
+    auto members = builder.getOrCreateArray(membersMetadata);
+    return builder.createStructType(currentScope(),
+                                    llvmType->getStructName(),
+                                    compileUnit->getFile(),
+                                    0,
+                                    structLayout->getSizeInBits(),
+                                    structLayout->getAlignment().value() * 8,
+                                    llvm::DINode::FlagZero,
+                                    nullptr,
+                                    members);
+}
+
+llvm::DIType *DebugContext::createUnionType(const Type *type)
+{
+    auto &layout = module.getDataLayout();
+    auto llvmType = getLLVMType(type);
+    auto unionLayout = layout.getStructLayout(
+        llvm::dyn_cast_or_null<llvm::StructType>(llvmType));
+    std::vector<llvm::Metadata *> metadata;
+
+    for (u64 i = 0; i < type->tUnion.count; i++) {
+        auto elLlvmType = getLLVMType(type->tUnion.members[i].type);
+        auto diType = getDIType(type->tUnion.members[i].type);
+        auto diTypeSize = layout.getTypeSizeInBits(elLlvmType);
+        auto diTypeAlign = layout.getABITypeAlign(elLlvmType).value() * 8;
+        metadata.push_back(builder.createMemberType(currentScope(),
+                                                    std::to_string(i),
+                                                    compileUnit->getFile(),
+                                                    1 /* LineNo */,
+                                                    diTypeSize,
+                                                    diTypeAlign,
+                                                    0 /* OffsetInBits */,
+                                                    llvm::DINode::FlagZero,
+                                                    diType));
+        auto size = layout.getTypeAllocSize(elLlvmType);
+    }
+
+    auto diUnionType = builder.createUnionType(
+        currentScope(),
+        llvm::StringRef() /* Name */,
+        compileUnit->getFile(),
+        1 /* LineNumber */,
+        layout.getTypeSizeInBits(llvmType->getContainedType(1)),
+        layout.getABITypeAlign(llvmType->getContainedType(1)).value() * 8,
+        llvm::DINode::FlagZero,
+        builder.getOrCreateArray(metadata));
+
+    metadata.clear();
+    llvm::DIType *tag = nullptr;
+    auto diTagAlign =
+        layout.getABITypeAlign(llvmType->getContainedType(0)).value();
+    if (diTagAlign == 1)
+        tag = getDIType(getPrimitiveType(types, prtU8));
+    else if (diTagAlign == 2)
+        tag = getDIType(getPrimitiveType(types, prtU16));
+    else if (diTagAlign == 4)
+        tag = getDIType(getPrimitiveType(types, prtU32));
+    else
+        tag = getDIType(getPrimitiveType(types, prtU64));
+
+    metadata.push_back(builder.createMemberType(
+        currentScope(),
+        "tag" /* Name */,
+        compileUnit->getFile(),
+        1 /* LineNo */,
+        layout.getTypeSizeInBits(llvmType->getContainedType(0)),
+        diTagAlign * 8,
+        0 /* OffsetInBits */,
+        llvm::DINode::FlagZero,
+        tag));
+
+    metadata.push_back(builder.createMemberType(
+        currentScope(),
+        "value" /* Name */,
+        compileUnit->getFile(),
+        1 /* LineNo */,
+        layout.getTypeSizeInBits(llvmType->getContainedType(1)),
+        layout.getABITypeAlign(llvmType->getContainedType(1)).value() * 8,
+        unionLayout->getElementOffsetInBits(1),
+        llvm::DINode::FlagZero,
+        diUnionType));
+
+    return builder.createStructType(currentScope(),
+                                    llvmType->getStructName(),
+                                    compileUnit->getFile(),
+                                    1 /* LineNumber */,
+                                    layout.getTypeSizeInBits(llvmType),
+                                    layout.getABITypeAlign(llvmType).value() *
+                                        8,
+                                    llvm::DINode::FlagZero,
+                                    nullptr /* DerivedFrom */,
+                                    builder.getOrCreateArray(metadata));
+}
+
+llvm::DIType *DebugContext::createEnumType(const Type *type)
+{
+    auto llvmBaseType = getLLVMType(type->tEnum.base);
+    auto &layout = module.getDataLayout();
+    std::vector<llvm::Metadata *> optionsDescriptors;
+    for (u64 i = 0; i < type->tEnum.optionsCount; i++) {
+        auto &option = type->tEnum.options[i];
+        optionsDescriptors.push_back(builder.createEnumerator(
+            option.name, option.value, isUnsignedType(type->tEnum.base)));
+    }
+
+    auto enumeratorArray = builder.getOrCreateArray(optionsDescriptors);
+    return builder.createEnumerationType(
+        currentScope(),
+        type->name,
+        compileUnit->getFile(),
+        type->tEnum.decl->loc.begin.row,
+        layout.getTypeSizeInBits(llvmBaseType),
+        layout.getABITypeAlign(llvmBaseType).value() * 8,
+        enumeratorArray,
+        getDIType(type->tEnum.base));
+}
+
+llvm::DIType *DebugContext::createFunctionType(const Type *type)
+{
+    std::vector<llvm::Metadata *> paramsMetadata;
+    auto decl = type->func.decl;
+
+    paramsMetadata.push_back(getDIType(type->func.retType));
+    if (decl && decl->funcDecl.this_) {
+        paramsMetadata.push_back(getDIType(decl->funcDecl.this_->type));
+    }
+
+    for (u64 i = 0; i < type->func.paramsCount; i++) {
+        paramsMetadata.push_back(getDIType(type->func.params[i]));
+    }
+
+    return builder.createSubroutineType(
+        builder.getOrCreateTypeArray(paramsMetadata));
+}
+
+void DebugContext::addFields(std::vector<llvm::Metadata *> &elements,
+                             const llvm::StructLayout &structLayout,
+                             TypeMembersContainer &members)
+{
+    auto layout = module.getDataLayout();
+    for (u64 i = 0; i < members.count; i++) {
+        auto &member = members.members[i];
+        if (!nodeIs(member.decl, FieldDecl))
+            continue;
+
+        auto diType = getDIType(member.type);
+        auto diTypeSize = diType->getSizeInBits();
+        auto llvmType = getLLVMType(member.type);
+        auto alignment = layout
+                             .getABITypeAlign(typeIs(member.type, Func)
+                                                  ? llvmType->getPointerTo()
+                                                  : llvmType)
+                             .value() *
+                         8;
+        auto flags = hasFlag(member.decl, Private) ? llvm::DINode::FlagPrivate
+                                                   : llvm::DINode::FlagPublic;
+
+        elements.push_back(
+            builder.createMemberType(currentScope(),
+                                     member.name,
+                                     compileUnit->getFile(),
+                                     member.decl->loc.begin.row,
+                                     diTypeSize,
+                                     alignment,
+                                     structLayout.getElementOffsetInBits(i),
+                                     flags,
+                                     diType));
+    }
+}
+
+llvm::DebugLoc DebugContext::getDebugLoc(const AstNode *node)
+{
+    llvm::DILocation *DILoc = llvm::DILocation::get(module.getContext(),
+                                                    node->loc.begin.row,
+                                                    node->loc.begin.col,
+                                                    currentScope());
+    return llvm::DebugLoc(DILoc);
+}
+
+llvm::DILocalVariable *DebugContext::emitParamDecl(const AstNode *node,
+                                                   u64 index,
+                                                   llvm::BasicBlock *block)
+{
+    auto value = getLlvmValue(node);
+    csAssert0(llvm::isa<llvm::DILocalScope>(currentScope()));
+    auto diType = getDIType(node->type);
+    if (typeIs(node->type, Func))
+        diType = builder.createPointerType(
+            diType, module.getDataLayout().getPointerSize());
+
+    llvm::DILocalVariable *diLocalVar =
+        builder.createParameterVariable(currentScope(),
+                                        node->funcParam.name,
+                                        index,
+                                        compileUnit->getFile(),
+                                        node->loc.begin.row,
+                                        diType,
+                                        true);
+    builder.insertDeclare(value,
+                          diLocalVar,
+                          builder.createExpression(),
+                          getDebugLoc(node),
+                          block);
+
+    return diLocalVar;
+}
+
+void DebugContext::emitDebugLoc(const AstNode *node, llvm::Value *value)
+{
+    auto instr = llvm::dyn_cast_or_null<llvm::Instruction>(value);
+    if (instr != nullptr) {
+        llvm::DebugLoc debugLoc = getDebugLoc(node);
+        instr->setDebugLoc(debugLoc);
+    }
+}
+
+llvm::DILocalVariable *DebugContext::emitLocalVariable(const AstNode *node,
+                                                       llvm::BasicBlock *block)
+{
+    auto value = getLlvmValue(node);
+    csAssert0(llvm::isa<llvm::DILocalScope>(currentScope()));
+    auto diType = getDIType(node->type);
+    auto diLocalVar = builder.createAutoVariable(currentScope(),
+                                                 node->funcParam.name,
+                                                 compileUnit->getFile(),
+                                                 node->loc.begin.row,
+                                                 diType);
+    builder.insertDeclare(value,
+                          diLocalVar,
+                          builder.createExpression(),
+                          getDebugLoc(node),
+                          block);
+
+    return diLocalVar;
+}
+
+void DebugContext::emitGlobalVariable(const AstNode *node)
+{
+    auto value = llvm::dyn_cast<llvm::GlobalVariable>(getLlvmValue(node));
+    llvm::DIGlobalVariableExpression *diGlobalVar =
+        builder.createGlobalVariableExpression(currentScope(),
+                                               node->varDecl.name,
+                                               value->getName(),
+                                               compileUnit->getFile(),
+                                               node->loc.begin.row,
+                                               getDIType(node->type),
+                                               false);
+    value->addDebugInfo(diGlobalVar);
+}
+
+void DebugContext::emitFunctionDecl(const AstNode *node)
+{
+    auto func = getLlvmFunction(node);
+    auto flags = llvm::DINode::FlagPrototyped;
+    auto spFlags = llvm::DISubprogram::SPFlagDefinition;
+
+    if (hasFlag(node, Public))
+        flags |= llvm::DINode::FlagPublic;
+    if (hasFlag(node, Virtual)) {
+        if (node->funcDecl.body == nullptr)
+            spFlags |= llvm::DISubprogram::SPFlagPureVirtual;
+        else
+            spFlags |= llvm::DISubprogram::SPFlagVirtual;
+    }
+
+    llvm::DISubroutineType *diType =
+        llvm::dyn_cast_or_null<llvm::DISubroutineType>(getDIType(node->type));
+
+    llvm::DISubprogram *sub;
+    if (node->funcDecl.this_) {
+        sub = builder.createMethod(currentScope(),
+                                   node->funcDecl.name,
+                                   func->getName(),
+                                   compileUnit->getFile(),
+                                   node->loc.begin.row,
+                                   diType,
+                                   0 /* VTableIndex */,
+                                   0 /* ThisAdjustment */,
+                                   nullptr /* VTableHolder */,
+                                   flags,
+                                   spFlags);
+    }
+    else {
+        sub = builder.createFunction(currentScope(),
+                                     node->funcDecl.name,
+                                     func->getName(),
+                                     compileUnit->getFile(),
+                                     node->loc.begin.row,
+                                     diType,
+                                     node->loc.begin.row,
+                                     flags,
+                                     spFlags);
+    }
+    scopes.push_back(sub);
+    func->setSubprogram(sub);
+}
+
+void DebugContext::sealFunctionDecl(const AstNode *node)
+{
+    auto func = getLlvmFunction(node);
+    if (auto sub = func->getSubprogram()) {
+        builder.finalizeSubprogram(sub);
+    }
+    scopes.pop_back();
+}
+
+void DebugContext::finalize() { builder.finalize(); }
+
+} // namespace cxy

--- a/src/cxy/lang/backend/llvm/debug.h
+++ b/src/cxy/lang/backend/llvm/debug.h
@@ -4,9 +4,86 @@
 
 #pragma once
 
+#include <driver/driver.h>
 #include <lang/frontend/ast.h>
+
+#include <llvm/IR/DIBuilder.h>
+#include <llvm/IR/DebugInfo.h>
+#include <llvm/IR/DebugLoc.h>
+#include <llvm/IR/GlobalVariable.h>
 
 namespace cxy {
 
-class DebugContext {};
+struct LLVMContext;
+
+class DebugContext {
+public:
+    DebugContext(llvm::Module &module,
+                 CompilerDriver *driver,
+                 cstring fileName);
+
+    llvm::DIType *getDIType(const Type *type);
+
+    llvm::DILocalVariable *emitParamDecl(const AstNode *node,
+                                         u64 index,
+                                         llvm::BasicBlock *block);
+    llvm::DILocalVariable *emitLocalVariable(const AstNode *node,
+                                             llvm::BasicBlock *block);
+
+    llvm::DebugLoc getDebugLoc(const AstNode *node);
+
+    void emitGlobalVariable(const AstNode *node);
+
+    void emitFunctionDecl(const AstNode *node);
+    void sealFunctionDecl(const AstNode *node);
+    void emitDebugLoc(const AstNode *node, llvm::Value *value);
+    void finalize();
+
+private:
+    llvm::DIType *convertToDIType(const Type *type);
+    llvm::DIType *pointerToDIType(const Type *type);
+    llvm::DIType *arrayToDIType(const Type *type);
+    llvm::DIType *createStructType(const Type *type);
+    llvm::DIType *createClassType(const Type *type);
+    llvm::DIType *createTupleType(const Type *type);
+    llvm::DIType *createFunctionType(const Type *type);
+    llvm::DIType *createEnumType(const Type *type);
+    llvm::DIType *createUnionType(const Type *type);
+    void addFields(std::vector<llvm::Metadata *> &elements,
+                   const llvm::StructLayout &structLayout,
+                   TypeMemberContainer &members);
+
+    llvm::DIScope *currentScope()
+    {
+        if (scopes.empty())
+            scopes.push_back(compileUnit->getFile());
+        return scopes.back();
+    }
+
+    llvm::Value *getLlvmValue(const AstNode *node)
+    {
+        return static_cast<llvm::Value *>(node->codegen);
+    }
+
+    llvm::Function *getLlvmFunction(const AstNode *node)
+    {
+        return llvm::dyn_cast<llvm::Function>(getLlvmValue(node));
+    }
+
+    llvm::Type *getLLVMType(const Type *type)
+    {
+        if (typeIs(type, Wrapped))
+            type = type->wrapped.target;
+        csAssert0(type->codegen);
+        return static_cast<llvm::Type *>(type->codegen);
+    }
+
+private:
+    llvm::DIBuilder builder;
+    llvm::DICompileUnit *compileUnit{nullptr};
+    llvm::Module &module;
+    TypeTable *types{nullptr};
+    llvm::SmallVector<llvm::DIScope *, 4> scopes{};
+};
+
 } // namespace cxy

--- a/src/cxy/lang/backend/llvm/llvm.cpp
+++ b/src/cxy/lang/backend/llvm/llvm.cpp
@@ -8,6 +8,8 @@
 #include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/CodeGen/CommandFlags.h>
+#include <llvm/IR/DIBuilder.h>
+#include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Linker/Linker.h>
@@ -91,6 +93,121 @@ LLVMBackend::LLVMBackend(CompilerDriver *driver, llvm::TargetMachine *TM)
     updateType(types->voidType, llvm::Type::getVoidTy(*_context));
     updateType(types->nullType,
                llvm::Type::getVoidTy(*_context)->getPointerTo());
+
+    // DI types
+    updateDebug(types->primitiveTypes[prtBool],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtBool]->name,
+                                       1 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_signed,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtI8],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtI8]->name,
+                                       8 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_signed,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtI16],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtI16]->name,
+                                       16 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_signed,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtI32],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtI32]->name,
+                                       32 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_signed,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtI64],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtI64]->name,
+                                       64 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_signed,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtU8],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtU8]->name,
+                                       8 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_unsigned,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtU16],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtU16]->name,
+                                       16 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_unsigned,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtU32],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtU32]->name,
+                                       32 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_unsigned,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtU64],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtU64]->name,
+                                       64 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_unsigned,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtCChar],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtCChar]->name,
+                                       8 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_signed_char,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtChar],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtChar]->name,
+                                       32 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_unsigned_char,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtF32],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtF32]->name,
+                                       32 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_float,
+                                       llvm::DINode::FlagZero));
+    updateDebug(types->primitiveTypes[prtF64],
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->primitiveTypes[prtF64]->name,
+                                       64 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_float,
+                                       llvm::DINode::FlagZero));
+
+    updateDebug(types->voidType,
+                llvm::DIBasicType::get(*_context,
+                                       llvm::dwarf::DW_TAG_base_type,
+                                       types->voidType->name,
+                                       0 /* SizeInBits */,
+                                       0 /* AlignInBits */,
+                                       llvm::dwarf::DW_ATE_address,
+                                       llvm::DINode::FlagZero));
 }
 
 bool LLVMBackend::addModule(std::unique_ptr<llvm::Module> module)
@@ -122,7 +239,7 @@ bool LLVMBackend::linkModules()
     }
     modules.clear();
 
-    // optimizeModule(*_linkedModule);
+    optimizeModule(*_linkedModule);
     return true;
 }
 
@@ -240,6 +357,11 @@ bool LLVMBackend::linkGeneratedOutput(
     for (int i = 0; i < options.libraries.size; i++) {
         ccArgs.push_back("-l");
         ccArgs.push_back(dynArrayAt(const char **, &options.libraries, i));
+    }
+
+    if (options.debug) {
+        ccArgs.push_back("-g");
+        ccArgs.push_back("-O0");
     }
 
     std::vector<llvm::StringRef> ccArgStringRefs(ccArgs.begin(), ccArgs.end());

--- a/src/cxy/lang/backend/llvm/llvm.h
+++ b/src/cxy/lang/backend/llvm/llvm.h
@@ -55,4 +55,10 @@ static inline void *updateType(const Type *type, void *codegen)
     return codegen;
 }
 
+static inline void *updateDebug(const Type *type, void *codegen)
+{
+    const_cast<Type *>(type)->dbg = codegen;
+    return codegen;
+}
+
 } // namespace cxy

--- a/src/cxy/lang/frontend/flag.h
+++ b/src/cxy/lang/frontend/flag.h
@@ -70,7 +70,8 @@ extern "C" {
     f(ModuleInit,           53)                 \
     f(Move,                 54)                 \
     f(Moved,                55)                 \
-    f(BlockValue,           56)
+    f(BlockValue,           56)                 \
+    f(DiDisable,            57)
 
 // clang-format on
 static const u64 flgNone = 0;

--- a/src/cxy/lang/middle/comptime.h
+++ b/src/cxy/lang/middle/comptime.h
@@ -1,0 +1,8 @@
+//
+// Created by Carter Mbotho on 2024-01-09.
+//
+
+#ifndef CXY_COMPTIME_H
+#define CXY_COMPTIME_H
+
+#endif // CXY_COMPTIME_H

--- a/src/cxy/lang/middle/simplify/simplify.c
+++ b/src/cxy/lang/middle/simplify/simplify.c
@@ -901,7 +901,7 @@ static void simplifyMainModule(SimplifyContext *ctx, AstNode *program)
     AstNode *ctors = makeVarDecl(
         ctx->pool,
         builtinLoc(),
-        flgTopLevelDecl | flgConst,
+        flgTopLevelDecl | flgConst | flgDiDisable,
         makeString(ctx->strings, S___LLVM_global_ctors),
         NULL,
         makeArrayExpr(


### PR DESCRIPTION
* Generated binary does not contain debug symbols (tested by emitting assembly code and compiling it with `clang -g -O0`)
* DI info for generated variadic functions will always point to the current module (not the module on which it is defined)
* Builtins source code is embedded in the executable, need to figure out how we can generate a DI file for the file.