### PR TITLE
[#29] Fixed optimization hanging bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,8 @@ llvm_map_components_to_libnames(llvm_libs
         Linker
         TransformUtils
         CodeGen
+        Passes
+        Support
 )
 list(APPEND llvm_libs clangAST clangBasic clangFrontend clangLex clangParse clangSema)
 message(STATUS ${llvm_libs})

--- a/benchmarks/nbodies.cxy
+++ b/benchmarks/nbodies.cxy
@@ -155,11 +155,11 @@ pub func main() {
 
     bodies.[0].offsetMomentum(px, py, pz);
 
-    for(const i: 0..50000000) {
+    for(const i: 0:i32..50000000) {
         bodiesAdvance(bodies, <u64>5, 1.0e-5);
     }
 
     for (const i: 0..5) {
-        print(f"${bodies.[i].mass}\n")
+        printf("%g\n", bodies.[i].mass)
     }
 }

--- a/examples/hello.cxy
+++ b/examples/hello.cxy
@@ -1,13 +1,6 @@
-struct User {
-    name: string
-}
-
-struct Account {
-    user: User
-
-    const func `str`(os: OutputStream) {
-        os << user.name
-    }
+@[pure]
+pub func __cxy_panic2(file: string, line: u64, column: u64, msg: string) {
+    write(2, "\n  @", 4)
 }
 
 pub func main() {

--- a/src/cxy/core/log.c
+++ b/src/cxy/core/log.c
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -476,4 +477,20 @@ const FileLoc *builtinLoc(void)
     static FileLoc builtin = {
         .fileName = NULL, .begin = {0, 0, 0}, .end = {0, 0, 0}};
     return &builtin;
+}
+
+void printStatus(Log *L, const char *fmt, ...)
+{
+    if (L->progress) {
+        static int lastPrinted = 0;
+        if (lastPrinted) {
+            printf("\r%*c", lastPrinted, ' ');
+        }
+        va_list args;
+        printf("\r");
+        va_start(args, fmt);
+        lastPrinted = vprintf(fmt, args);
+        va_end(args);
+        fflush(stdout);
+    }
 }

--- a/src/cxy/core/log.h
+++ b/src/cxy/core/log.h
@@ -71,6 +71,7 @@ typedef struct Log {
         u64 num;
     } enabledWarnings;
     bool showDiagnostics;
+    bool progress;
 } Log;
 
 typedef struct DiagnosticMemoryPrintCtx {
@@ -86,6 +87,7 @@ void logWarning(Log *, const FileLoc *, const char *, const FormatArg *);
 void logWarningWithId(
     Log *, u8, const FileLoc *, const char *, const FormatArg *);
 void logNote(Log *, const FileLoc *, const char *, const FormatArg *);
+void printStatus(Log *L, const char *fmt, ...);
 
 void printDiagnosticToConsole(const Diagnostic *diag, void *ctx);
 void printDiagnosticToMemory(const Diagnostic *diag, void *ctx);

--- a/src/cxy/core/utils.h
+++ b/src/cxy/core/utils.h
@@ -208,7 +208,7 @@ attr(noreturn) attr(format, printf, 1, 2) void cxyAbort(const char *fmt, ...);
 #define csAssert0(cond) cxyAssert((cond), "")
 
 #define cDEF "\x1B[0m"
-#define cRED "\x1B[32m"
+#define cRED "\x1B[31m"
 #define cGRN "\x1B[32m"
 #define cYLW "\x1B[33m"
 #define cBLU "\x1B[34m"
@@ -217,7 +217,7 @@ attr(noreturn) attr(format, printf, 1, 2) void cxyAbort(const char *fmt, ...);
 #define cWHT "\x1B[37m"
 
 #define cBOLD "\x1B[1;0m"
-#define cBRED "\x1B[1;32m"
+#define cBRED "\x1B[1;31m"
 #define cBGRN "\x1B[1;32m"
 #define cBYLW "\x1B[1;33m"
 #define cBBLU "\x1B[1;34m"

--- a/src/cxy/driver/driver.c
+++ b/src/cxy/driver/driver.c
@@ -102,6 +102,7 @@ attr(always_inline) static char *getCachedAstPath(Options *options,
 static AstNode *parseFile(CompilerDriver *driver, const char *fileName)
 {
     size_t file_size = 0;
+    printStatus(driver->L, cWHT "Parsing %s..." cDEF, fileName);
     char *fileData = readFile(fileName, &file_size);
     if (!fileData) {
         logError(driver->L,
@@ -130,6 +131,7 @@ static AstNode *parseString(CompilerDriver *driver,
 {
     Lexer lexer = newLexer(fileName ?: "builtins", code, codeSize, driver->L);
     Parser parser = makeParser(&lexer, driver);
+    printStatus(driver->L, cWHT "Parsing string @ %s" cDEF, fileName);
     AstNode *program = parseProgram(&parser);
 
     freeLexer(&lexer);
@@ -217,10 +219,17 @@ static bool compileProgram(CompilerDriver *driver,
 
 compileProgramDone:
     stopCompilerStats(driver);
-    bool dumpStats = !options->dev.cleanAst &&
-                     !hasFlag(metadata, BuiltinsModule) &&
+    bool dumpStats = !hasFlag(metadata, BuiltinsModule) &&
                      !(hasFlag(program, ImportedModule));
     if (dumpStats) {
+        if (hasErrors(driver->L))
+            printStatus(driver->L,
+                        cBRED "\xE2\x9C\x92" cBWHT
+                              " Compilation failure\n" cDEF);
+        else
+            printStatus(driver->L,
+                        cBGRN "\xE2\x9C\x93" cBWHT
+                              " Compilation success\n" cDEF);
         compilerStatsPrint(driver);
     }
     return status;

--- a/src/cxy/driver/options.h
+++ b/src/cxy/driver/options.h
@@ -26,6 +26,18 @@ typedef enum {
 #undef ff
 } DumpModes;
 
+#define DRIVER_STATS_MODE(f)    \
+    f(NONE)                     \
+    f(SUMMARY)                  \
+    f(FULL)
+
+typedef enum {
+#define ff(N) dsm##N,
+    DRIVER_STATS_MODE(ff)
+    dsmCOUNT
+#undef ff
+} DumpStatsMode;
+
 typedef enum OptimizationLevel {
     O0,
     Od = O0,
@@ -60,6 +72,10 @@ typedef struct Options {
     bool withMemoryManager;
     bool debug;
     OptimizationLevel optimizationLevel;
+    bool debugPassManager;
+    cstring passes;
+    DynArray loadPassPlugins;
+    DumpStatsMode dsmMode;
     struct {
         bool printIR;
         bool emitBitCode;
@@ -71,7 +87,6 @@ typedef struct Options {
         DumpModes dumpMode;
         u64 lastStage;
     } dev;
-    bool progress;
 } Options;
 
 /// Parse command-line options, and remove those parsed options from the

--- a/src/cxy/driver/stages.c
+++ b/src/cxy/driver/stages.c
@@ -381,13 +381,10 @@ AstNode *executeCompilerStage(CompilerDriver *driver,
         return node;
     }
 
-    if (driver->options.progress) {
-        logNote(driver->L,
-                NULL,
-                "executing '{s}' id",
-                (FormatArg[]){{.s = stageName}});
-    }
-
+    cstring name =
+        nodeIs(node, Metadata) ? node->metadata.filePath : node->loc.fileName;
+    printStatus(
+        driver->L, cBWHT "* %s %s..." cDEF, stageName, name ?: "<unknown>");
     compilerStatsSnapshot(driver);
     node = executor(driver, node);
     compilerStatsRecord(driver, stage);

--- a/src/cxy/driver/stats.c
+++ b/src/cxy/driver/stats.c
@@ -8,9 +8,41 @@
 
 #include <inttypes.h>
 
-#define BYTES_TO_GB(B) (((double)(B)) / 1000000000)
-#define BYTES_TO_MB(B) (((double)(B)) / 1000000)
-#define BYTES_TO_KB(B) (((double)(B)) / 1000)
+#define BYTES_1KB 1000.0
+#define BYTES_1MB (1000.0 * BYTES_1KB)
+#define BYTES_1GB (1000.0 * BYTES_1MB)
+
+#define BYTES_TO_GB(B) (((double)(B)) / BYTES_1GB)
+#define BYTES_TO_MB(B) (((double)(B)) / BYTES_1MB)
+#define BYTES_TO_KB(B) (((double)(B)) / BYTES_1KB)
+
+static void compilerPrintSummarySize(const CompilerStats *stats)
+{
+    if (stats->snapshot.poolStats.totalAllocated < BYTES_1KB) {
+        printf("%zu bytes (%zu bytes / %zu blocks)",
+               stats->snapshot.poolStats.totalUsed,
+               stats->snapshot.poolStats.totalAllocated,
+               stats->snapshot.poolStats.numberOfBlocks);
+    }
+    else if (stats->snapshot.poolStats.totalAllocated < BYTES_1MB) {
+        printf("%g Kb (%g Kb / %zu blocks)",
+               BYTES_TO_KB(stats->snapshot.poolStats.totalUsed),
+               BYTES_TO_KB(stats->snapshot.poolStats.totalAllocated),
+               stats->snapshot.poolStats.numberOfBlocks);
+    }
+    else if (stats->snapshot.poolStats.totalAllocated < BYTES_1GB) {
+        printf("%g Mb (%g Mb / %zu blocks)",
+               BYTES_TO_MB(stats->snapshot.poolStats.totalUsed),
+               BYTES_TO_MB(stats->snapshot.poolStats.totalAllocated),
+               stats->snapshot.poolStats.numberOfBlocks);
+    }
+    else {
+        printf("%g Gb (%g Gb / %zu blocks)",
+               BYTES_TO_GB(stats->snapshot.poolStats.totalUsed),
+               BYTES_TO_GB(stats->snapshot.poolStats.totalAllocated),
+               stats->snapshot.poolStats.numberOfBlocks);
+    }
+}
 
 void compilerStatsSnapshot(CompilerDriver *driver)
 {
@@ -53,41 +85,55 @@ void compilerStatsRecord(CompilerDriver *driver, CompilerStage stage)
 
 void compilerStatsPrint(const struct CompilerDriver *driver)
 {
-    // clang-format off
+    const Options *options = &driver->options;
+    if ((options->cmd == cmdDev && options->dev.cleanAst) ||
+        options->dsmMode == dsmNONE)
+        return;
+
+    if (options->dsmMode == dsmFULL) {
+        // clang-format off
     printf("+---------------+---------------+-----------------------------------------------+\n");
     printf("|               |               |              Memory Usage                     |\n");
     printf("| Stage         | Duration (ms) |-------------+----------------+----------------|\n");
     printf("|               |               | # of Blocks | Allocated (Kb) | Used (Kb)      |\n");
-    // clang-format on
-    for (CompilerStage stage = ccsInvalid + 1; stage != ccsCOUNT; stage++) {
-        __typeof(driver->stats.stages[stage]) *stats =
-            &driver->stats.stages[stage];
-        if (!stats->captured)
-            continue;
-        // clang-format off
-        printf("|---------------+---------------+-------------+----------------+----------------|\n");
         // clang-format on
-        printf("| %-14s|%14" PRIu64 " |%12zu |%15g |%15g |\n",
-               getCompilerStageDescription(stage),
-               stats->duration,
-               stats->pool.numberOfBlocks,
-               BYTES_TO_KB(stats->pool.totalAllocated),
-               BYTES_TO_KB(stats->pool.totalUsed));
+        for (CompilerStage stage = ccsInvalid + 1; stage != ccsCOUNT; stage++) {
+            __typeof(driver->stats.stages[stage]) *stats =
+                &driver->stats.stages[stage];
+            if (!stats->captured)
+                continue;
+            // clang-format off
+        printf("|---------------+---------------+-------------+----------------+----------------|\n");
+            // clang-format on
+            printf("| %-14s|%14" PRIu64 " |%12zu |%15g |%15g |\n",
+                   getCompilerStageDescription(stage),
+                   stats->duration,
+                   stats->pool.numberOfBlocks,
+                   BYTES_TO_KB(stats->pool.totalAllocated),
+                   BYTES_TO_KB(stats->pool.totalUsed));
+        }
+
+        printf(cBWHT);
+        // clang-format off
+        printf("+---------------+---------------+-------------+----------------+----------------+\n");
+        // clang-format on
+
+        printf("| Total         |%14" PRIu64 " |%12zu |%15g |%15g |\n",
+               driver->stats.duration,
+               driver->stats.snapshot.poolStats.numberOfBlocks,
+               BYTES_TO_KB(driver->stats.snapshot.poolStats.totalAllocated),
+               BYTES_TO_KB(driver->stats.snapshot.poolStats.totalUsed));
+
+        // clang-format off
+        printf("+---------------+---------------+-------------+----------------+----------------+\n");
+        // clang-format on
+        printf(cDEF);
     }
-
-    printf(cBOLD);
-    // clang-format off
-    printf("+---------------+---------------+-------------+----------------+----------------+\n");
-    // clang-format on
-
-    printf("| Total         |%14" PRIu64 " |%12zu |%15g |%15g |\n",
-           driver->stats.duration,
-           driver->stats.snapshot.poolStats.numberOfBlocks,
-           BYTES_TO_KB(driver->stats.snapshot.poolStats.totalAllocated),
-           BYTES_TO_KB(driver->stats.snapshot.poolStats.totalUsed));
-
-    // clang-format off
-    printf("+---------------+---------------+-------------+----------------+----------------+\n");
-    // clang-format on
-    printf(cDEF);
+    else {
+        printf(cBWHT);
+        printf("   memory: ");
+        compilerPrintSummarySize(&driver->stats);
+        printf("\n   duration: %" PRIu64 " ms\n", driver->stats.duration);
+        printf(cDEF);
+    }
 }

--- a/src/cxy/lang/backend/llvm/generate.cpp
+++ b/src/cxy/lang/backend/llvm/generate.cpp
@@ -510,8 +510,8 @@ static void visitCallExpr(AstVisitor *visitor, AstNode *node)
             return;
         args.push_back(value);
     }
-
-    ctx.returnValue(ctx.builder.CreateCall(funcType, callee, args));
+    auto value = ctx.builder.CreateCall(funcType, callee, args);
+    ctx.returnValue(value);
 }
 
 static void visitStructExpr(AstVisitor *visitor, AstNode *node)

--- a/src/cxy/lang/middle/builtins.h
+++ b/src/cxy/lang/middle/builtins.h
@@ -16,7 +16,8 @@ extern "C" {
     f(timestamp)                   \
     f(evin)                        \
     f(evout)                       \
-    f(sleep)
+    f(sleep)                       \
+    f(istimeout)
 
 // clang-format on
 

--- a/src/cxy/lang/middle/sema/inheritance.c
+++ b/src/cxy/lang/middle/sema/inheritance.c
@@ -29,7 +29,7 @@ static AstNode *makeVTableVariable(TypingContext *ctx,
     AstNode *vTable = makeVarDecl(
         ctx->pool,
         &node->loc,
-        flgConst | flgTopLevelDecl,
+        flgConst | flgTopLevelDecl | (node->flags & flgPublic),
         makeStringConcat(ctx->strings, getDeclarationName(node), "_vTable"),
         NULL,
         makeStructExpr(ctx->pool,

--- a/src/cxy/runtime/builtins.cxy
+++ b/src/cxy/runtime/builtins.cxy
@@ -38,7 +38,7 @@ else {
 
 macro errno() =(*__error())
 
-@[pure, inline]
+@[pure]
 pub func __cxy_panic(file: string, line: u64, column: u64, msg: string) {
     var buf: [char, 64];
     write(2, "panic: ", 7)
@@ -340,9 +340,9 @@ pub class OutputStream {
     @inline
     func appendBool(val: bool) {
         if (val)
-            append("true" !: &const char, 4)
+            append("true" !: &const char, 4:u64)
         else
-            append("false" !: &const char, 5)
+            append("false" !: &const char, 5:u64)
     }
 
     func appendPointer[T](ptr: &const T) {

--- a/src/cxy/stdlib/coro.cxy
+++ b/src/cxy/stdlib/coro.cxy
@@ -281,13 +281,14 @@ class CoroutineScheduler {
         suspend()
     }
 
-    func fdWaitWrite(fd: i32) {
+    func fdWaitWrite(fd: i32, timeout: u64) {
         var status = ae.aeCreateFileEvent(
             eventLoop,
             fd,
             ae.State.AE_WRITABLE,
             eventLoopCallback,
-            running !: &void
+            running !: &void,
+            timeout
         );
         if (status == ae.Status.AE_OK) {
             // suspend the current coroutine
@@ -297,13 +298,14 @@ class CoroutineScheduler {
         return status
     }
 
-    func fdWaitRead(fd: i32) {
+    func fdWaitRead(fd: i32, timeout: u64) {
         var status = ae.aeCreateFileEvent(
             eventLoop,
             fd,
             ae.State.AE_READABLE,
             eventLoopCallback,
-            running !: &void
+            running !: &void,
+            timeout
         );
         if (status == .AE_OK) {
             // suspend the current coroutine
@@ -357,10 +359,13 @@ macro spawn(BLOCK) __spawn!(BLOCK!, null)
 func __now() => ae.aeOsTime()
 
 @[inline, __override_builtin("evin")]
-func __evin(fd: i32, timeout: i64 = -1) => __scheduler.fdWaitRead(fd)
+func __evin(fd: i32, timeout: u64 = 0) => __scheduler.fdWaitRead(fd, timeout)
 
 @[inline, __override_builtin("evout")]
-func __evout(fd: i32, timeout: i64 = -1) => __scheduler.fdWaitWrite(fd)
+func __evout(fd: i32, timeout: u64 = 0) => __scheduler.fdWaitWrite(fd, timeout)
 
 @[inline, __override_builtin("sleep")]
 func __sleep(ms: i64) { __scheduler.sleep(ms) }
+
+@[inline, __override_builtin("istimeout")]
+func __istimeout(status: i32) => (status & ae.State.AE_TIMEOUT) == ae.State.AE_TIMEOUT

--- a/src/cxy/stdlib/tcp.cxy
+++ b/src/cxy/stdlib/tcp.cxy
@@ -21,7 +21,7 @@ func configureSocket(fd: i32)  {
     assert!(rc == 0);
 
     opt = 1;
-    rc = socket.setsockopt(fd, SOL_SOCKET!, SO_NOSIGPIPE!, &opt, sizeof!(opt) !:u32);
+    rc = socket.setsockopt(fd, SOL_SOCKET!, SO_NOSIGPIPE!, &opt, <u32>sizeof!(opt));
     assert!(rc == 0 && errno! != EINVAL!);
 }
 
@@ -50,7 +50,7 @@ pub class TcpSocket {
     @inline
     const func address() => addr
 
-    func receive(buffer: &void, size: u64, deadline: i64 = 0): u64? {
+    func receive(buffer: &void, size: u64, timeout: u64 = 0): u64? {
         var remaining = size;
         var data = buffer !: &char;
         var total: u64 = 0;
@@ -70,7 +70,7 @@ pub class TcpSocket {
                 if (total > 0)
                     return total
 
-                var rc = evin(fd);
+                var rc = evin(fd, timeout);
                 if (rc != State.AE_READABLE) {
                     errno! = ETIMEDOUT!;
                     return null
@@ -86,7 +86,7 @@ pub class TcpSocket {
         return total
     }
 
-    func sendBuffer(buffer: &const void, size: u64, deadline: i64 = 0): u64? {
+    func sendBuffer(buffer: &const void, size: u64, timeout: u64 = 0): u64? {
         var data = buffer !: &const char;
         var remaining = size;
         var total: u64 = 0;
@@ -102,7 +102,7 @@ pub class TcpSocket {
                 if(errno! != EAGAIN! && errno! != EWOULDBLOCK!)
                     return null
 
-                var rc = evout(fd);
+                var rc = evout(fd, timeout);
                 if (rc != State.AE_WRITABLE) {
                     errno! = ETIMEDOUT!
                     return null
@@ -117,17 +117,17 @@ pub class TcpSocket {
         return total
     }
 
-    func send[T](data: T, deadline: i64 = 0) {
+    func send[T](data: T, timeout: u64 = 0) {
         #if (T.isString) {
             #if (T.isStruct) {
-                return sendBuffer(data.str !: &void, len!(data), deadline)
+                return sendBuffer(data.str !: &void, len!(data), timeout)
             }
             else {
-                return sendBuffer(data !: &void, len!(data), deadline)
+                return sendBuffer(data !: &void, len!(data), timeout)
             }
         }
         else #if (T.isSlice) {
-            return sendBuffer(data.data, data.count, deadline)
+            return sendBuffer(data.data, data.count, timeout)
         }
         else {
             error!("type {t} cannot be sent as is, consider using sendBuffer", T)
@@ -191,7 +191,7 @@ pub class TcpListener {
         return true
     }
 
-    func accept(deadline: i64 = 0): TcpSocket? {
+    func accept(timeout: u64 = 0): TcpSocket? {
         var addr: Address;
         while (this) {
             /* Try to get new connection (non-blocking). */
@@ -204,7 +204,7 @@ pub class TcpListener {
             if (errno! != EAGAIN! && errno! != EWOULDBLOCK!)
                 return null
             /* Wait till new connection is available. */
-            var rc = evin(fd);
+            var rc = evin(fd, timeout);
             if (rc != State.AE_READABLE) {
                 errno! = ETIMEDOUT!;
                 return null

--- a/src/tools/amalgamate.c
+++ b/src/tools/amalgamate.c
@@ -91,7 +91,8 @@ int main(int argc, char *argv[])
         modified = MAX(modified, mtime);
 
         size += bytes;
-        size += fprintf(output, "\\n/*---------%s----------*/\\n", argv[j]) - 2;
+        // size += fprintf(output, "\\n/*---------%s----------*/\\n", argv[j]) -
+        // 2;
         for (u64 i = 0; i < bytes; i++) {
             if (data[i] == '"') {
                 fputc('\\', output);

--- a/tests/lang/frontend/parser/run.cfg
+++ b/tests/lang/frontend/parser/run.cfg
@@ -1,2 +1,2 @@
-run_args="dev --dump-ast CXY --no-color --clean-ast --with-named-enums --last-stage=Parse  --without-builtins --max-errors 20"
+run_args="dev --dump-ast CXY --no-color --no-progress --clean-ast --with-named-enums --last-stage=Parse  --without-builtins --max-errors 20"
 snapshot_ext=.cxy

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -143,7 +143,7 @@ timestamp() {
 TESTS_DIR=$(realpath $(dirname "$0"))
 CXY_DEFAULT_COMMAND=./cxy
 CXY_STDLIB=./stdlib
-CXY_DEFAULT_ARGS="dev --dump-ast CXY --no-color --clean-ast --warnings=~RedundantStmt"
+CXY_DEFAULT_ARGS="dev --dump-ast CXY --no-color --no-progress --clean-ast --warnings=~RedundantStmt"
 CXY_DEFAULT_SNAPSHOT_EXT=".cxy"
 
 POSITIONAL_ARGS=()


### PR DESCRIPTION
The issue was mainly on the frontend where we retype integer constants. Fixed the hang by removing the re-type to a cast in the offending cxy function. Also added the following
- Print current compiler status
- Print compilation summary instead of a table by default.

Created #31 to follow up on optimization issues
Created #32 to fix the retyping bug.