### PR TITLE
Adding mir code for the language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,12 @@ set(CXY_MIDDLE_SOURCES
 
         src/cxy/lang/middle/mem/manage.c
         src/cxy/lang/middle/mem/mem.c
-        src/cxy/lang/middle/mem/reference.c)
+        src/cxy/lang/middle/mem/reference.c
+
+        src/cxy/lang/middle/mir/context.c
+        src/cxy/lang/middle/mir/node.c
+        src/cxy/lang/middle/mir/print.c
+)
 
 if (ENABLE_LLVM_BACKEND)
     set(CXY_LANG_BACKEND_SOURCES

--- a/examples/hello.cxy
+++ b/examples/hello.cxy
@@ -1,18 +1,14 @@
-import { Server, Request, Response } from "stdlib/http.cxy"
 import { FileServer } from "stdlib/fserver.cxy"
-
-func own(v: String) {
-}
-
-func borrow(x: &const String) {
-}
-
-func mutate(x: &String) {
-
-}
+import { Server } from "stdlib/http.cxy"
 
 func main(args: [string]) {
-    var server = Server[()]();
-    var fs = FileServer(&server);
-    server.start()
+     var server = Server[()]();
+     var fs = FileServer(&server);
+     server.start()
 }
+
+
+// hello
+// h e a p
+//       t
+//   a d

--- a/src/cxy/core/format.h
+++ b/src/cxy/core/format.h
@@ -89,6 +89,7 @@ void format(FormatState *, const char *format_str, const FormatArg *args);
 void append(FormatState *, const char *s, size_t bytes);
 void printWithStyle(FormatState *, const char *, FormatStyle);
 void printKeyword(FormatState *, const char *);
+void printAssemblyString(FormatState *, const char *);
 void printUtf8(FormatState *state, uint32_t, bool);
 void printEscapedChar(FormatState *state, char chr);
 void writeFormatState(const FormatState *, FILE *);

--- a/src/cxy/core/strpool.c
+++ b/src/cxy/core/strpool.c
@@ -34,6 +34,19 @@ static bool compareStrInsert(const void *left, const void *right)
     return !strncmp(*(char **)left, str->s, str->len);
 }
 
+static cstring makeStringVargs(StrPool *strings, const char *fmt, va_list args)
+{
+    size_t size = 0;
+    char *buf = NULL;
+    FILE *fp = open_memstream(&buf, &size);
+    csAssert0(fp);
+    vfprintf(fp, fmt, args);
+    fclose(fp);
+    cstring str = makeStringSized(strings, buf, size);
+    free(buf);
+    return str;
+}
+
 const char *makeString(StrPool *str_pool, const char *str)
 {
     return str ? makeStringSized(str_pool, str, strlen(str)) : NULL;
@@ -116,23 +129,11 @@ const char *makeStringConcat_(StrPool *pool, const char *s1, ...)
     return makeString(pool, variable);
 }
 
-const char *makeStringVf(StrPool *strings, const char *fmt, va_list args)
-{
-    char *buf = NULL;
-    size_t size = strlen(fmt) + 128;
-    FILE *fp = open_memstream(&buf, &size);
-    int ret = vfprintf(fp, fmt, args);
-    fclose(fp);
-    const char *str = makeStringSized(strings, buf, ret);
-    free(buf);
-    return str;
-}
-
 const char *makeStringf(StrPool *strings, const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    const char *str = makeStringVf(strings, fmt, ap);
+    const char *str = makeStringVargs(strings, fmt, ap);
     va_end(ap);
     return str;
 }

--- a/src/cxy/core/strpool.h
+++ b/src/cxy/core/strpool.h
@@ -42,6 +42,8 @@ const char *makeStringConcat_(StrPool *, const char *, ...);
 #define makeStringConcat(P, S1, ...)                                           \
     makeStringConcat_((P), (S1), ##__VA_ARGS__, NULL)
 
+const char *makeStringf(StrPool *strings, const char *fmt, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cxy/driver/driver.c
+++ b/src/cxy/driver/driver.c
@@ -14,6 +14,7 @@
 #include "lang/frontend/strings.h"
 #include "lang/frontend/ttable.h"
 #include "lang/middle/builtins.h"
+#include "lang/middle/mir/context.h"
 
 #include "src/builtins.h"
 
@@ -283,6 +284,8 @@ bool initCompilerDriver(CompilerDriver *compiler,
 
     internCommonStrings(compiler->strings);
     const Options *options = &compiler->options;
+    compiler->mir = mirContextCreate(compiler);
+    csAssert0(compiler->mir);
     compiler->backend = initCompilerBackend(compiler, argc, argv);
     csAssert0(compiler->backend);
     initCompilerPreprocessor(compiler);

--- a/src/cxy/driver/driver.h
+++ b/src/cxy/driver/driver.h
@@ -10,6 +10,8 @@
 extern "C" {
 #endif
 
+struct MirContext;
+
 typedef struct CompilerPreprocessor {
     MemPool *pool;
     HashTable symbols;
@@ -33,6 +35,7 @@ typedef struct CompilerDriver {
     AstNode *mainModule;
     AstNodeList startup;
     CompilerPreprocessor preprocessor;
+    struct MirContext *mir;
     void *backend;
     void *cImporter;
     bool hasTestCases;

--- a/src/cxy/lang/frontend/ttable.c
+++ b/src/cxy/lang/frontend/ttable.c
@@ -515,6 +515,34 @@ const Type *resolveAndUnThisType(const Type *type)
     return NULL;
 }
 
+const Type *resolveUnThisUnwrapType(const Type *type)
+{
+    while (type) {
+        switch (type->tag) {
+        case typAlias:
+            type = resolveUnThisUnwrapType(type->alias.aliased);
+            break;
+        case typInfo:
+            type = resolveUnThisUnwrapType(type->info.target);
+            break;
+        case typOpaque:
+            if (hasFlag(type, ForwardDecl)) {
+                return resolveUnThisUnwrapType(type->opaque.decl->type) ?: type;
+            }
+            return type;
+        case typThis:
+            type = resolveUnThisUnwrapType(type->_this.that);
+            break;
+        case typWrapped:
+            type = resolveUnThisUnwrapType(type->wrapped.target);
+            break;
+        default:
+            return type;
+        }
+    }
+    return NULL;
+}
+
 const Type *stripPointer(const Type *type)
 {
     while (true) {

--- a/src/cxy/lang/frontend/ttable.h
+++ b/src/cxy/lang/frontend/ttable.h
@@ -43,6 +43,8 @@ const Type *resolveType(const Type *type);
 
 const Type *resolveAndUnThisType(const Type *type);
 
+const Type *resolveUnThisUnwrapType(const Type *type);
+
 const Type *stripPointer(const Type *type);
 
 const Type *stripReference(const Type *type);

--- a/src/cxy/lang/frontend/types.h
+++ b/src/cxy/lang/frontend/types.h
@@ -132,6 +132,8 @@ typedef struct AppliedTypeParams {
     u64 count;
 } AppliedTypeParams;
 
+struct MirType;
+
 #define CXY_TYPE_HEAD                                                          \
     TTag tag;                                                                  \
     u64 size;                                                                  \
@@ -147,7 +149,8 @@ typedef struct AppliedTypeParams {
             bool generating;                                                   \
             bool generated;                                                    \
         };                                                                     \
-    };
+    };                                                                         \
+    const struct MirType *mir;
 
 #ifdef __cpluplus
 

--- a/src/cxy/lang/middle/eval/for.c
+++ b/src/cxy/lang/middle/eval/for.c
@@ -92,7 +92,8 @@ static bool evalExprForStmtVariadic(AstVisitor *visitor,
     EvalContext *ctx = getAstVisitorContext(visitor);
     AstNode *range = node->forStmt.range, *variable = node->forStmt.var;
 
-    csAssert0(nodeIs(range, FuncParamDecl));
+    csAssert0(nodeIs(range, Identifier));
+    range = range->ident.resolvesTo;
     if (typeIs(range->type, Void))
         return true;
 
@@ -234,7 +235,7 @@ void evalForStmt(AstVisitor *visitor, AstNode *node)
         if (!evalExprForStmtArray(visitor, node, &nodes))
             return;
         break;
-    case astFuncParamDecl:
+    case astIdentifier:
         if (!hasFlag(node->forStmt.range, Variadic)) {
             logError(ctx->L,
                      &rangeLoc,

--- a/src/cxy/lang/middle/eval/path.c
+++ b/src/cxy/lang/middle/eval/path.c
@@ -122,6 +122,12 @@ void evalPathEpilogue(AstVisitor *visitor,
             csAssert0(false);
         }
     }
+    else if (nodeIs(symbol, FuncParamDecl)) {
+        node->tag = astIdentifier;
+        node->ident.value = symbol->funcParam.name;
+        node->ident.resolvesTo = symbol;
+        node->flags |= (symbol->flags & flgVariadic);
+    }
     else {
         replaceAstNodeWith(
             node, nodeIs(symbol, VarDecl) ? symbol->varDecl.init : symbol);

--- a/src/cxy/lang/middle/mem/reference.c
+++ b/src/cxy/lang/middle/mem/reference.c
@@ -34,28 +34,6 @@ static bool isIdentifier(const AstNode *node)
     }
 }
 
-static AstNode *resolveIdentifier(AstNode *node)
-{
-    switch (node->tag) {
-    case astIdentifier:
-        return node->ident.resolvesTo;
-    case astCastExpr:
-    case astTypedExpr:
-        return resolveIdentifier(node->castExpr.expr);
-    case astGroupExpr:
-        return resolveIdentifier(node->groupExpr.expr);
-    case astPointerOf:
-    case astReferenceOf:
-    case astUnaryExpr: {
-        Operator op = node->unaryExpr.op;
-        if (op == opMove || op == opPtrof || opRefof || op == opDeref)
-            return resolveIdentifier(node->unaryExpr.operand);
-    }
-    default:
-        return NULL;
-    }
-}
-
 const AstNode *resolveCallExpr(const AstNode *node)
 {
     if (node == NULL)

--- a/src/cxy/lang/middle/mir/context.c
+++ b/src/cxy/lang/middle/mir/context.c
@@ -1,0 +1,20 @@
+//
+// Created by Carter Mbotho on 2024-11-01.
+//
+
+#include "core/alloc.h"
+#include "driver/driver.h"
+
+#include "context.h"
+
+MirContext *mirContextCreate(struct CompilerDriver *cc)
+{
+    csAssert0(cc->mir == NULL);
+    cc->mir = callocOrDie(sizeof(MirContext), 1);
+    cc->mir->L = cc->L;
+    cc->mir->pool = cc->pool;
+    cc->mir->strings = cc->strings;
+    cc->mir->types = cc->types;
+
+    return cc->mir;
+}

--- a/src/cxy/lang/middle/mir/context.h
+++ b/src/cxy/lang/middle/mir/context.h
@@ -1,0 +1,43 @@
+//
+// Created by Carter Mbotho on 2024-11-01.
+//
+
+#pragma once
+
+#include <core/array.h>
+#include <core/utils.h>
+
+struct MirType;
+struct Log;
+struct MemPool;
+struct CompilerDriver;
+
+// clang-format off
+#define CXY_MIR_FLAGS(f)        \
+    f(None,            0)       \
+    f(Const,           1)       \
+    f(Reference,       2)       \
+    f(Pointer,         3)       \
+    f(Extern,          4)       \
+    f(Inline,          5)       \
+    f(NoInline,        6)       \
+    f(NoOptimize,      7)       \
+    f(Constructor,     8)       \
+    f(Destructor,      9)
+// clang-format off
+
+#define f(NAME, VALUE) static u64 mif##NAME = BIT(VALUE);
+CXY_MIR_FLAGS(f)
+#undef f
+
+typedef struct MirContext {
+    struct Log *L;
+    struct MemPool *pool;
+    struct StrPool *strings;
+    struct TypeTable *types;
+    DynArray modules;
+} MirContext;
+
+MirContext *mirContextCreate(struct CompilerDriver *cc);
+void mirContextDestroy(struct CompilerDriver *cc);
+u64 astFlagsToMirFlags(u64 flags);

--- a/src/cxy/lang/middle/mir/node.c
+++ b/src/cxy/lang/middle/mir/node.c
@@ -1,0 +1,1803 @@
+//
+// Created by Carter Mbotho on 2024-11-01.
+//
+
+#include <core/alloc.h>
+
+#include <driver/driver.h>
+#include <lang/frontend/ttable.h>
+#include <lang/frontend/visitor.h>
+
+#include "context.h"
+
+#include "lang/frontend/strings.h"
+#include "node.h"
+
+typedef struct AstToMirContext {
+    MirContext *mir;
+    MirNode *ret;
+    MirNodeList globals;
+
+    union {
+        struct {
+            MirNode *func;
+            MirNode *returnVar;
+            MirNode *exitBasicBlock;
+            MirNode *currentBasicBlock;
+            MirNode *loopUpdateBasicBlock;
+            MirNode *endBasicBlock;
+            MirNodeList basicBlocks;
+            HashTable uniqueNames;
+        };
+        struct {
+            MirNode *func;
+            MirNode *returnVar;
+            MirNode *exitBasicBlock;
+            MirNode *currentBasicBlock;
+            MirNode *loopUpdateBasicBlock;
+            MirNode *endBasicBlock;
+            MirNodeList basicBlocks;
+            HashTable uniqueNames;
+        } mirFnCtx;
+    };
+} AstToMirContext;
+
+typedef typeof((AstToMirContext){}.mirFnCtx) MirFunctionContext;
+typedef struct {
+    cstring prefix;
+    u64 idx;
+} Label;
+
+static bool stringEqual(const void *lhs, const void *rhs)
+{
+    return compareStrings(((Label *)lhs)->prefix, ((Label *)rhs)->prefix) == 0;
+}
+
+static inline cstring makeUniqueString(AstToMirContext *ctx, cstring prefix)
+{
+    Label elem = {.prefix = prefix};
+    u64 idx = 0;
+    HashCode hash = hashStr(hashInit(), prefix);
+    Label *found = findInHashTable(
+        &ctx->uniqueNames, &elem, hash, sizeof(elem), stringEqual);
+    if (found) {
+        idx = found->idx++;
+    }
+    else {
+        elem.idx = 1;
+        insertInHashTable(
+            &ctx->uniqueNames, &elem, hash, sizeof(elem), stringEqual);
+    }
+    if (idx)
+        return makeStringf(ctx->mir->strings, "%s%d", prefix, idx);
+    else
+        return makeString(ctx->mir->strings, prefix);
+}
+
+const Type *typeGetElement(MirContext *ctx, const Type *type)
+{
+    type = resolveUnThisUnwrapType(type);
+    if (typeIs(type, Array))
+        return resolveUnThisUnwrapType(type->array.elementType);
+    else if (typeIs(type, Pointer))
+        return resolveUnThisUnwrapType(type->pointer.pointed);
+    else if (typeIs(type, String))
+        return ctx->types->primitiveTypes[prtCChar];
+    unreachable("Unknown type");
+}
+
+const Type *typeReturnType(const Type *type)
+{
+    csAssert0(typeIs(type, Func));
+    return resolveUnThisUnwrapType(type->func.retType);
+}
+
+const Type *typeGetMember(const Type *type, u64 index)
+{
+    type = resolveUnThisUnwrapType(type);
+    type = stripAll(type);
+    TypeMembersContainer *members = NULL;
+    switch (type->tag) {
+    case typTuple:
+        csAssert0(index < type->tuple.count);
+        return resolveUnThisUnwrapType(type->tuple.members[index]);
+    case typUnion:
+        csAssert0(index < type->tUnion.count);
+        return resolveUnThisUnwrapType(type->tUnion.members[index].type);
+    case typStruct:
+        members = type->tStruct.members;
+        break;
+    case typClass:
+        members = type->tClass.members;
+        break;
+    case typUntaggedUnion:
+        members = type->untaggedUnion.members;
+        break;
+    default:
+        csAssert0(false);
+    }
+
+    csAssert0(index < members->count);
+    return resolveUnThisUnwrapType(members->members[index].type);
+}
+
+static MirNode *makeLocalVar(AstToMirContext *ctx,
+                             const FileLoc *loc,
+                             cstring name,
+                             const Type *type)
+{
+    csAssert0(ctx->currentBasicBlock);
+    return mirNodeListInsert(&ctx->currentBasicBlock->BasicBlock.nodes,
+                             makeMirAllocaOp(ctx->mir, loc, name, type, NULL));
+}
+
+static inline MirNode *makeLocalTempVar(AstToMirContext *ctx,
+                                        const FileLoc *loc,
+                                        const Type *type)
+{
+    csAssert0(ctx->currentBasicBlock);
+    return mirNodeListInsert(
+        &ctx->currentBasicBlock->BasicBlock.nodes,
+        makeMirAllocaOp(
+            ctx->mir, loc, makeUniqueString(ctx, "tmp"), type, NULL));
+}
+
+static inline MirNode *insertInCurrentBlock(AstToMirContext *ctx, MirNode *node)
+{
+    csAssert0(ctx->currentBasicBlock);
+    return mirNodeListInsert(&ctx->currentBasicBlock->BasicBlock.nodes, node);
+}
+
+static inline MirNode *insertGlobalVariable(AstToMirContext *ctx, MirNode *node)
+{
+    csAssert0(mirIs(node, GlobalVariable));
+    return mirNodeListInsert(&ctx->globals, node);
+}
+
+static inline MirNode *insertBasicBlock(AstToMirContext *ctx, MirNode *bb)
+{
+    return mirNodeListInsert(&ctx->basicBlocks, bb);
+}
+
+static bool isMirBasicBlockTerminated(const MirNode *node)
+{
+    MirNode *last = node->BasicBlock.nodes.last;
+    if (mirIs(last, JumpOp) || mirIs(last, IfOp) || mirIs(last, PanicOp) ||
+        mirIs(last, ReturnOp))
+        return true;
+    return false;
+}
+
+#define astToMirRet(MIR)                                                       \
+    ({                                                                         \
+        MirNode *LINE_VAR(_mir) = MIR;                                         \
+        ctx->ret = LINE_VAR(_mir);                                             \
+        node->mir = LINE_VAR(_mir);                                            \
+    })
+
+static MirNode *convertAstToMir(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    MirNode *mir = NULL;
+    ctx->ret = NULL;
+    if (node) {
+        astVisit(visitor, node);
+        mir = ctx->ret;
+    }
+    ctx->ret = NULL;
+    return mir;
+}
+
+static u64 getStructMemberInfo(const AstNode *member, u64 *flags)
+{
+    csAssert0(nodeIs(member, Identifier));
+    member = member->ident.resolvesTo;
+    if (isReferenceType(member->type))
+        *flags |= mifReference;
+    else if (isPointerType(member->type))
+        *flags |= mifPointer;
+
+    if (nodeIs(member, FieldDecl))
+        return member->structField.index;
+    else if (nodeIs(member, FieldExpr))
+        return member->fieldExpr.index;
+    unreachable("")
+}
+
+static void visitNullLit(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(makeMirNullConst(ctx->mir, &node->loc, node->type, NULL));
+}
+
+static void visitBoolLit(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(
+        makeMirBoolConst(ctx->mir, &node->loc, node->boolLiteral.value, NULL));
+}
+
+static void visitCharLit(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    if (node->type->primitive.id == prtChar)
+        astToMirRet(makeMirCharConst(
+            ctx->mir, &node->loc, (char)node->charLiteral.value, NULL));
+    else
+        astToMirRet(
+            makeMirUnsignedConst(ctx->mir,
+                                 &node->loc,
+                                 node->charLiteral.value,
+                                 ctx->mir->types->primitiveTypes[prtU32],
+                                 NULL));
+}
+
+static void visitIntegerLit(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    if (isSignedType(node->type)) {
+        astToMirRet(makeMirSignedConst(
+            ctx->mir, &node->loc, node->intLiteral.value, node->type, NULL));
+    }
+    else {
+        astToMirRet(makeMirUnsignedConst(
+            ctx->mir, &node->loc, node->intLiteral.uValue, node->type, NULL));
+    }
+}
+
+static void visitFloatLit(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(makeMirFloatConst(
+        ctx->mir, &node->loc, node->floatLiteral.value, node->type, NULL));
+}
+
+static void visitStringLit(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(makeMirStringConst(
+        ctx->mir, &node->loc, node->stringLiteral.value, NULL));
+}
+
+static void visitIdentifier(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    csAssert0(node->ident.resolvesTo);
+    AstNode *resolved = node->ident.resolvesTo;
+    csAssert0(resolved->mir);
+
+    astToMirRet(withMirFlags(
+        makeMirLoadOp(
+            ctx->mir, &node->loc, node->ident.value, resolved->mir, NULL),
+        resolved->mir->flags));
+}
+
+static void visitArrayExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *elem = node->arrayExpr.elements;
+    MirNodeList elems = {};
+    u64 i = 0;
+    for (; elem; elem = elem->next, i++) {
+        mirNodeListInsert(&elems, convertAstToMir(visitor, elem));
+    }
+
+    if (node->arrayExpr.isLiteral) {
+        astToMirRet(makeMirArrayConst(
+            ctx->mir, &node->loc, elems.first, i, node->type, NULL));
+    }
+    else {
+        astToMirRet(makeMirArrayInitOp(
+            ctx->mir, &node->loc, elems.first, i, node->type, NULL));
+    }
+}
+
+static void visitTupleExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *elem = node->tupleExpr.elements;
+    MirNodeList elems = {};
+    u64 i = 0;
+    for (; elem; elem = elem->next, i++) {
+        mirNodeListInsert(&elems, convertAstToMir(visitor, elem));
+    }
+
+    if (node->tupleExpr.isLiteral) {
+        astToMirRet(makeMirStructConst(
+            ctx->mir, &node->loc, elems.first, i, node->type, NULL));
+    }
+    else {
+        astToMirRet(makeMirStructInitOp(
+            ctx->mir, &node->loc, elems.first, i, node->type, NULL));
+    }
+}
+
+static void visitFieldExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(convertAstToMir(visitor, node->fieldExpr.value));
+}
+
+static void visitStructExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *elem = node->structExpr.fields;
+    MirNodeList elems = {};
+    u64 i = 0;
+    for (; elem; elem = elem->next, i++) {
+        mirNodeListInsert(&elems, convertAstToMir(visitor, elem));
+    }
+
+    if (node->structExpr.isLiteral) {
+        astToMirRet(makeMirStructConst(
+            ctx->mir, &node->loc, elems.first, i, node->type, NULL));
+    }
+    else {
+        astToMirRet(makeMirStructInitOp(
+            ctx->mir, &node->loc, elems.first, i, node->type, NULL));
+    }
+}
+
+static void visitUnaryExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    Operator op = node->unaryExpr.op;
+    AstNode *operand = node->unaryExpr.operand;
+
+    switch (op) {
+    case opMinus:
+    case opPlus:
+    case opNot:
+    case opCompl:
+        astToMirRet(
+            makeMirUnaryOp(ctx->mir,
+                           &node->loc,
+                           node->unaryExpr.op,
+                           convertAstToMir(visitor, node->unaryExpr.operand),
+                           NULL));
+        break;
+    case opPreInc:
+    case opPreDec: {
+        // ++a => a = a + 1; a
+        MirNode *mirOperand = convertAstToMir(visitor, operand);
+        insertInCurrentBlock(
+            ctx,
+            makeMirAssignOp(
+                ctx->mir,
+                &operand->loc,
+                mirOperand,
+                makeMirBinaryOp(
+                    ctx->mir,
+                    &node->loc,
+                    cloneMirNode(ctx->mir, mirOperand),
+                    op == opPreDec ? opSub : opAdd,
+                    makeMirSignedConst(
+                        ctx->mir, &node->loc, 1, operand->type, NULL),
+                    operand->type,
+                    NULL),
+                NULL));
+        astToMirRet(cloneMirNode(ctx->mir, mirOperand));
+        break;
+    }
+    case opPostInc:
+    case opPostDec: {
+        // a++ => tmp = a; a = a+1
+        MirNode *tmp = makeLocalTempVar(ctx, &operand->loc, operand->type);
+        MirNode *mirOperand = convertAstToMir(visitor, operand);
+        insertInCurrentBlock(
+            ctx,
+            makeMirAssignOp(
+                ctx->mir,
+                &node->loc,
+                makeMirLoadOp(
+                    ctx->mir, &operand->loc, tmp->AllocaOp.name, tmp, NULL),
+                mirOperand,
+                NULL));
+        // a =  a + 1
+        insertInCurrentBlock(
+            ctx,
+            makeMirAssignOp(
+                ctx->mir,
+                &operand->loc,
+                cloneMirNode(ctx->mir, mirOperand),
+                makeMirBinaryOp(
+                    ctx->mir,
+                    &node->loc,
+                    cloneMirNode(ctx->mir, mirOperand),
+                    op == opPreDec ? opSub : opAdd,
+                    makeMirSignedConst(
+                        ctx->mir, &node->loc, 1, operand->type, NULL),
+                    operand->type,
+                    NULL),
+                NULL));
+        astToMirRet(
+            makeMirLoadOp(ctx->mir, &tmp->loc, tmp->AllocaOp.name, tmp, NULL));
+        break;
+    }
+    case opMove:
+        astToMirRet(makeMirMoveOp(
+            ctx->mir, &node->loc, convertAstToMir(visitor, operand), NULL));
+        break;
+    default:
+        break;
+    }
+}
+
+static void visitBinaryExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    Operator op = node->binaryExpr.op;
+    AstNode *lhs = node->binaryExpr.lhs, *rhs = node->binaryExpr.rhs;
+    astToMirRet(makeMirBinaryOp(ctx->mir,
+                                &node->loc,
+                                convertAstToMir(visitor, lhs),
+                                op,
+                                convertAstToMir(visitor, rhs),
+                                node->type,
+                                NULL));
+}
+
+static void visitAssignExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    Operator op = node->assignExpr.op;
+    AstNode *lhs = node->assignExpr.lhs, *rhs = node->assignExpr.rhs;
+    MirNode *mLhs = convertAstToMir(visitor, lhs),
+            *mRhs = convertAstToMir(visitor, rhs);
+    withMirFlags(mLhs, mRhs->flags);
+
+    if (op != opAssign) {
+        mRhs = makeMirBinaryOp(
+            ctx->mir, &node->loc, mLhs, op, mRhs, node->type, NULL);
+    }
+    astToMirRet(withMirFlags(
+        makeMirAssignOp(ctx->mir, &node->loc, mLhs, mRhs, NULL), mLhs->flags));
+}
+
+static void visitTernaryExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *ifTrue = node->ternaryExpr.body,
+            *ifFalse = node->ternaryExpr.otherwise;
+    MirNode *tmp = makeLocalTempVar(ctx, &node->loc, node->type);
+    cstring name = makeUniqueString(ctx, "if");
+    MirNode *phi =
+        makeMirBasicBlock(ctx->mir,
+                          &node->ternaryExpr.body->loc,
+                          makeStringf(ctx->mir->strings, "%s.end", name),
+                          NULL);
+    // if then
+    MirNode *bbTrue =
+        makeMirBasicBlock(ctx->mir,
+                          &node->ternaryExpr.body->loc,
+                          makeStringf(ctx->mir->strings, "%s.then", name),
+                          NULL);
+    // if otherwise
+    MirNode *bbFalse =
+        makeMirBasicBlock(ctx->mir,
+                          &node->ternaryExpr.body->loc,
+                          makeStringf(ctx->mir->strings, "%s.otherwise", name),
+                          NULL);
+
+    insertInCurrentBlock(
+        ctx,
+        makeMirIfOp(ctx->mir,
+                    &node->loc,
+                    convertAstToMir(visitor, node->ternaryExpr.cond),
+                    bbTrue,
+                    bbFalse,
+                    NULL));
+
+    insertBasicBlock(ctx, bbTrue);
+    ctx->currentBasicBlock = bbTrue;
+    MirNode *then = convertAstToMir(visitor, ifTrue);
+    withMirFlags(tmp, then->flags);
+
+    insertInCurrentBlock(
+        ctx,
+        makeMirAssignOp(
+            ctx->mir,
+            &ifTrue->loc,
+            makeMirLoadOp(
+                ctx->mir, &ifTrue->loc, tmp->AllocaOp.name, tmp, NULL),
+            then,
+            makeMirJumpOp(ctx->mir, &ifTrue->loc, phi, NULL)));
+
+    insertBasicBlock(ctx, bbFalse);
+    ctx->currentBasicBlock = bbFalse;
+    insertInCurrentBlock(
+        ctx,
+        makeMirAssignOp(
+            ctx->mir,
+            &ifFalse->loc,
+            makeMirLoadOp(
+                ctx->mir, &ifFalse->loc, tmp->AllocaOp.name, tmp, NULL),
+            convertAstToMir(visitor, ifFalse),
+            makeMirJumpOp(ctx->mir, &ifFalse->loc, phi, NULL)));
+
+    insertBasicBlock(ctx, phi);
+    ctx->currentBasicBlock = phi;
+    astToMirRet(
+        makeMirLoadOp(ctx->mir, &tmp->loc, tmp->AllocaOp.name, tmp, NULL));
+}
+
+static void visitCastExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *from = node->castExpr.expr, *to = node->castExpr.to;
+    MirNode *expr = convertAstToMir(visitor, from);
+    csAssert0(expr);
+    if (expr->type == to->type) {
+        astToMirRet(expr);
+        return;
+    }
+
+    u64 flags = hasFlag(to, Const) ? mifConst : mifNone;
+    if (isReferenceType(to->type))
+        flags |= mifReference;
+    else if (isPointerType(to->type))
+        flags |= mifPointer;
+
+    if (hasFlag(node, UnionCast) || typeIs(from->type, Union)) {
+        astToMirRet(withMirFlags(
+            makeMirMemberOp(
+                ctx->mir,
+                &node->loc,
+                makeMirMemberOp(ctx->mir, &node->loc, expr, 1, NULL),
+                node->castExpr.idx,
+                NULL),
+            flags));
+    }
+    else {
+        astToMirRet(withMirFlags(
+            makeMirCastOp(ctx->mir,
+                          &node->loc,
+                          expr,
+                          makeMirTypeInfo(ctx->mir, &to->loc, to->type, NULL),
+                          NULL),
+            flags));
+    }
+}
+
+static void visitTypedExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *from = node->castExpr.expr, *to = node->castExpr.to;
+    MirNode *expr = convertAstToMir(visitor, from);
+    csAssert0(expr);
+    if (expr->type == to->type) {
+        astToMirRet(expr);
+        return;
+    }
+
+    u64 flags = hasFlag(to, Const) ? mifConst : mifNone;
+    if (isReferenceType(to->type))
+        flags |= mifReference;
+    else if (isPointerType(to->type))
+        flags |= mifPointer;
+    astToMirRet(withMirFlags(
+        makeMirCastOp(ctx->mir,
+                      &node->loc,
+                      expr,
+                      makeMirTypeInfo(ctx->mir, &to->loc, to->type, NULL),
+                      NULL),
+        flags));
+}
+
+static void visitGroupExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(convertAstToMir(visitor, node->groupExpr.expr));
+}
+
+static void visitStmtExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(convertAstToMir(visitor, node->stmtExpr.stmt));
+}
+
+static void visitIndexExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *target = node->indexExpr.target, *index = node->indexExpr.index;
+    u64 flags = hasFlag(node, Const) ? mifConst : mifNone;
+    if (isReferenceType(target->type))
+        flags |= mifReference;
+    else if (isPointerType(target->type))
+        flags |= mifPointer;
+
+    astToMirRet(withMirFlags(makeMirIndexOp(ctx->mir,
+                                            &node->loc,
+                                            convertAstToMir(visitor, target),
+                                            convertAstToMir(visitor, index),
+                                            NULL),
+                             flags));
+}
+
+static void visitPointerOfExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    u64 flags = hasFlag(node, Const) ? mifConst : mifNone;
+    astToMirRet(withMirFlags(
+        makeMirPointerOfOp(ctx->mir,
+                           &node->loc,
+                           convertAstToMir(visitor, node->unaryExpr.operand),
+                           node->type,
+                           NULL),
+        flags));
+}
+
+static void visitReferenceOfExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    u64 flags = hasFlag(node, Const) ? mifConst : mifNone;
+    astToMirRet(withMirFlags(
+        makeMirReferenceOfOp(ctx->mir,
+                             &node->loc,
+                             convertAstToMir(visitor, node->unaryExpr.operand),
+                             node->type,
+                             NULL),
+        flags));
+}
+
+static void visitMemberExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *target = node->memberExpr.target,
+            *member = node->memberExpr.member;
+    if (nodeIsMemberFunctionReference(node)) {
+        AstNode *decl = member->ident.resolvesTo;
+        csAssert0(decl && decl->mir);
+        astToMirRet(makeMirLoadOp(
+            ctx->mir, &node->loc, decl->mir->Function.name, decl->mir, NULL));
+    }
+    else if (nodeIsEnumOptionReference(node)) {
+        member = member->ident.resolvesTo;
+        csAssert0(nodeIs(member, EnumOptionDecl));
+        const Type *base = member->type->tEnum.base;
+        if (isUnsignedType(base))
+            astToMirRet(makeMirUnsignedConst(
+                ctx->mir,
+                &node->loc,
+                member->enumOption.value->intLiteral.uValue,
+                base,
+                NULL));
+        else
+            astToMirRet(
+                makeMirSignedConst(ctx->mir,
+                                   &node->loc,
+                                   member->enumOption.value->intLiteral.value,
+                                   base,
+                                   NULL));
+    }
+    else if (typeIs(target->type, Module)) {
+        csAssert0(nodeIs(member, Identifier));
+        u64 flags = hasFlag(member, Const) ? mifConst : mifNone;
+        AstNode *decl = member->ident.resolvesTo;
+        csAssert0(decl && mirIs(decl->mir, GlobalVariable));
+        astToMirRet(withMirFlags(makeMirLoadOp(ctx->mir,
+                                               &node->loc,
+                                               decl->mir->GlobalVariable.name,
+                                               decl->mir,
+                                               NULL),
+                                 flags));
+    }
+    else {
+        u64 flags = hasFlag(member, Const) ? mifConst : mifNone;
+        u64 index = nodeIs(member, IntegerLit)
+                        ? member->intLiteral.uValue
+                        : getStructMemberInfo(member, &flags);
+
+        astToMirRet(makeMirMemberOp(ctx->mir,
+                                    &node->loc,
+                                    convertAstToMir(visitor, target),
+                                    index,
+                                    NULL));
+    }
+}
+
+static void visitCallExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    MirNodeList args = {};
+
+    MirNode *callee = convertAstToMir(visitor, node->callExpr.callee);
+    AstNode *arg = node->callExpr.args;
+    for (; arg; arg = arg->next) {
+        mirNodeListInsert(&args, convertAstToMir(visitor, arg));
+    }
+    const Type *ret = node->callExpr.callee->type->func.retType;
+    u64 flags = mifNone;
+    if (!typeIs(ret, Void)) {
+        flags |= hasFlag(node, Const) ? mifConst : mifNone;
+        if (isReferenceType(ret))
+            flags |= mifReference;
+        else if (isPointerType(ret))
+            flags |= mifPointer;
+    }
+
+    astToMirRet(withMirFlags(
+        makeMirCallOp(ctx->mir, &node->loc, callee, args.first, NULL, NULL),
+        flags));
+}
+
+static void visitUnionValue(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    const Type *type = makeStructType(
+        ctx->mir->types,
+        NULL,
+        (NamedTypeMember[]){{.name = makeString(ctx->mir->strings, "tag"),
+                             .type = ctx->mir->types->primitiveTypes[prtU32]},
+                            {.name = makeString(ctx->mir->strings, "value"),
+                             .type = node->type}},
+        2,
+        NULL,
+        flgNone);
+    MirNode *tmp = makeLocalTempVar(ctx, &node->unionValue.value->loc, type);
+    // tmp.0 = tag
+    insertInCurrentBlock(
+        ctx,
+        makeMirAssignOp( // tmp.0 = tag
+            ctx->mir,
+            &node->loc,
+            makeMirMemberOp(
+                ctx->mir,
+                &node->loc,
+                makeMirLoadOp(
+                    ctx->mir, &node->loc, tmp->AllocaOp.name, tmp, NULL),
+                0,
+                NULL),
+            makeMirUnsignedConst(ctx->mir,
+                                 &node->loc,
+                                 node->unionValue.idx,
+                                 ctx->mir->types->primitiveTypes[prtU64],
+                                 NULL),
+            makeMirAssignOp( // tmp.1.{idx} = value
+                ctx->mir,
+                &node->loc,
+                makeMirMemberOp( // tmp.1.{idx}
+                    ctx->mir,
+                    &node->loc,
+                    makeMirMemberOp( // tmp.1
+                        ctx->mir,
+                        &node->loc,
+                        makeMirLoadOp(ctx->mir,
+                                      &node->loc,
+                                      tmp->AllocaOp.name,
+                                      tmp,
+                                      NULL),
+                        1,
+                        NULL),
+                    node->unionValue.idx,
+                    NULL),
+                convertAstToMir(visitor, node->unionValue.value),
+                NULL)));
+    astToMirRet(
+        makeMirLoadOp(ctx->mir, &tmp->loc, tmp->AllocaOp.name, tmp, NULL));
+}
+
+static void visitBackendCallExpr(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    switch (node->backendCallExpr.func) {
+    case bfiAlloca:
+        astToMirRet(makeLocalTempVar(
+            ctx, &node->loc, node->backendCallExpr.args->type));
+        break;
+    case bfiSizeOf:
+        astToMirRet(makeMirSizeofOp(
+            ctx->mir, &node->loc, node->backendCallExpr.args->type, NULL));
+        break;
+    case bfiZeromem:
+        astToMirRet(makeMirZeromemOp(
+            ctx->mir,
+            &node->loc,
+            convertAstToMir(visitor, node->backendCallExpr.args),
+            NULL));
+        break;
+    }
+}
+
+static void visitAsmOperand(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    astToMirRet(
+        makeMirAsmOperand(ctx->mir,
+                          &node->loc,
+                          node->asmOperand.constraint,
+                          convertAstToMir(visitor, node->asmOperand.operand),
+                          NULL));
+}
+
+static void visitInlineAssembly(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    MirNodeList outputs = {}, inputs = {}, clobbers = {};
+    AstNode *output = node->inlineAssembly.outputs,
+            *input = node->inlineAssembly.inputs,
+            *clobber = node->inlineAssembly.clobbers;
+
+    for (; output; output = output->next) {
+        mirNodeListInsert(&outputs, convertAstToMir(visitor, output));
+    }
+
+    for (; input; input = input->next) {
+        mirNodeListInsert(&inputs, convertAstToMir(visitor, input));
+    }
+
+    for (; clobber; clobber = clobber->next) {
+        mirNodeListInsert(&clobbers, convertAstToMir(visitor, clobber));
+    }
+    astToMirRet(
+        insertInCurrentBlock(ctx,
+                             makeMirInlineAssembly(ctx->mir,
+                                                   &node->loc,
+                                                   node->inlineAssembly.text,
+                                                   outputs.first,
+                                                   inputs.first,
+                                                   clobbers.first,
+                                                   node->type,
+                                                   NULL)));
+}
+
+static void visitReturnStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *expr = node->returnStmt.expr;
+    if (expr) {
+        csAssert0(ctx->returnVar);
+        insertInCurrentBlock(
+            ctx,
+            makeMirAssignOp(ctx->mir,
+                            &node->loc,
+                            makeMirLoadOp(ctx->mir,
+                                          &expr->loc,
+                                          ctx->returnVar->AllocaOp.name,
+                                          ctx->returnVar,
+                                          NULL),
+                            convertAstToMir(visitor, expr),
+                            NULL));
+    }
+    astToMirRet(insertInCurrentBlock(
+        ctx, makeMirJumpOp(ctx->mir, &node->loc, ctx->exitBasicBlock, NULL)));
+}
+
+static void visitBlockStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *stmt = node->blockStmt.stmts;
+    MirNode *last = NULL;
+    for (; stmt; stmt = stmt->next) {
+        if (!hasFlag(node, BlockReturns) || stmt->next)
+            last = convertAstToMir(visitor, stmt);
+        else
+            last = convertAstToMir(visitor, stmt->exprStmt.expr);
+    }
+    astToMirRet(last);
+}
+
+static void visitExprStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *expr = node->exprStmt.expr;
+    MirNode *exprMir = convertAstToMir(visitor, node->exprStmt.expr);
+    if (nodeIs(expr, BlockStmt) || nodeIs(expr, ExprStmt))
+        astToMirRet(exprMir);
+    else
+        astToMirRet(insertInCurrentBlock(ctx, exprMir));
+}
+
+static void visitIfStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *ifTrue = node->ternaryExpr.body,
+            *ifFalse = node->ternaryExpr.otherwise;
+    cstring name = makeUniqueString(ctx, "if");
+    MirNode *phi =
+        makeMirBasicBlock(ctx->mir,
+                          &node->ternaryExpr.body->loc,
+                          makeStringf(ctx->mir->strings, "%s.end", name),
+                          NULL);
+
+    MirNode *bbTrue =
+        makeMirBasicBlock(ctx->mir,
+                          &node->ternaryExpr.body->loc,
+                          makeStringf(ctx->mir->strings, "%s.then", name),
+                          NULL);
+    MirNode *bbFalse =
+        ifFalse ? makeMirBasicBlock(
+                      ctx->mir,
+                      &node->ternaryExpr.body->loc,
+                      makeStringf(ctx->mir->strings, "%s.otherwise", name),
+                      NULL)
+                : phi;
+    MirNode *cond = convertAstToMir(visitor, node->ifStmt.cond);
+    MirNode *ifMir = insertInCurrentBlock(
+        ctx, makeMirIfOp(ctx->mir, &node->loc, cond, bbTrue, bbFalse, NULL));
+
+    insertBasicBlock(ctx, bbTrue);
+    ctx->currentBasicBlock = bbTrue;
+    astVisit(visitor, ifTrue);
+    if (!isMirBasicBlockTerminated(ctx->currentBasicBlock))
+        insertInCurrentBlock(ctx,
+                             makeMirJumpOp(ctx->mir, &ifTrue->loc, phi, NULL));
+    if (ifFalse) {
+        insertBasicBlock(ctx, bbFalse);
+        ctx->currentBasicBlock = bbFalse;
+        astVisit(visitor, ifFalse);
+        if (!isMirBasicBlockTerminated(ctx->currentBasicBlock))
+            insertInCurrentBlock(
+                ctx, makeMirJumpOp(ctx->mir, &ifFalse->loc, phi, NULL));
+    }
+    insertBasicBlock(ctx, phi);
+    ctx->currentBasicBlock = phi;
+    astToMirRet(ifMir);
+}
+
+static void visitWhileStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *cond = node->whileStmt.cond, *body = node->whileStmt.body,
+            *update = node->whileStmt.update;
+    cstring name = makeUniqueString(ctx, "while");
+    MirNode *condBb =
+        makeMirBasicBlock(ctx->mir,
+                          &cond->loc,
+                          makeStringf(ctx->mir->strings, "%s.cond", name),
+                          NULL);
+    MirNode *updateBb =
+        update ? makeMirBasicBlock(
+                     ctx->mir,
+                     &update->loc,
+                     makeStringf(ctx->mir->strings, "%s.update", name),
+                     NULL)
+               : condBb;
+    MirNode *bodyBb =
+        makeMirBasicBlock(ctx->mir,
+                          &body->loc,
+                          makeStringf(ctx->mir->strings, "%s.body", name),
+                          NULL);
+    MirNode *endBb =
+        makeMirBasicBlock(ctx->mir,
+                          &body->loc,
+                          makeStringf(ctx->mir->strings, "%s.end", name),
+                          NULL);
+
+    MirNode *currentLoopUpdateBb = ctx->loopUpdateBasicBlock,
+            *currentEndBasicBlock = ctx->endBasicBlock;
+    ctx->loopUpdateBasicBlock = updateBb;
+    ctx->endBasicBlock = endBb;
+
+    // jump into cond bb
+    insertInCurrentBlock(ctx,
+                         makeMirJumpOp(ctx->mir, &cond->loc, condBb, NULL));
+
+    insertBasicBlock(ctx, condBb);
+    ctx->currentBasicBlock = condBb;
+    insertInCurrentBlock(ctx,
+                         makeMirIfOp(ctx->mir,
+                                     &cond->loc,
+                                     convertAstToMir(visitor, cond),
+                                     bodyBb,
+                                     endBb,
+                                     NULL));
+    // Body
+    insertBasicBlock(ctx, bodyBb);
+    ctx->currentBasicBlock = bodyBb;
+    astVisit(visitor, body);
+
+    if (update) {
+        if (!isMirBasicBlockTerminated(ctx->currentBasicBlock))
+            insertInCurrentBlock(
+                ctx, makeMirJumpOp(ctx->mir, &body->loc, updateBb, NULL));
+        // update
+        insertBasicBlock(ctx, updateBb);
+        ctx->currentBasicBlock = updateBb;
+        astVisit(visitor, update);
+    }
+
+    if (!isMirBasicBlockTerminated(ctx->currentBasicBlock)) {
+        insertInCurrentBlock(ctx,
+                             makeMirJumpOp(ctx->mir, &body->loc, condBb, NULL));
+    }
+
+    insertBasicBlock(ctx, endBb);
+    ctx->currentBasicBlock = endBb;
+
+    ctx->loopUpdateBasicBlock = currentLoopUpdateBb;
+    ctx->endBasicBlock = currentEndBasicBlock;
+}
+
+static void visitSwitchStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    MirNodeList cases = {};
+    MirNode *cond = convertAstToMir(visitor, node->switchStmt.cond);
+    cstring name = makeUniqueString(ctx, "switch");
+    MirNode *endSwitch =
+        makeMirBasicBlock(ctx->mir,
+                          &node->ternaryExpr.body->loc,
+                          makeStringf(ctx->mir->strings, "%s.cond", name),
+                          NULL);
+
+    MirNode *currentEndBb = ctx->endBasicBlock;
+    ctx->endBasicBlock = endSwitch;
+
+    MirNode *switchMir = insertInCurrentBlock(
+        ctx, makeMirSwitchOp(ctx->mir, &node->loc, cond, NULL, NULL));
+    for (AstNode *it = node->switchStmt.cases; it; it = it->next) {
+        MirNode *bb = makeMirBasicBlock(
+            ctx->mir,
+            &node->ternaryExpr.body->loc,
+            makeStringf(
+                ctx->mir->strings, "%s.case%llu", name, it->caseStmt.idx),
+            NULL);
+        insertBasicBlock(ctx, bb);
+        ctx->currentBasicBlock = bb;
+        astVisit(visitor, it->caseStmt.body);
+        if (!isMirBasicBlockTerminated(bb))
+            insertInCurrentBlock(
+                ctx, makeMirJumpOp(ctx->mir, &it->loc, endSwitch, NULL));
+
+        if (it->caseStmt.match)
+            mirNodeListInsert(
+                &cases,
+                makeMirCaseOp(ctx->mir,
+                              &it->loc,
+                              convertAstToMir(visitor, it->caseStmt.match),
+                              bb,
+                              NULL));
+        else
+            switchMir->SwitchOp.def =
+                makeMirCaseOp(ctx->mir,
+                              &it->loc,
+                              convertAstToMir(visitor, it->caseStmt.match),
+                              bb,
+                              NULL);
+    }
+    // patch the switch op
+    switchMir->SwitchOp.cases = cases.first;
+    ctx->currentBasicBlock = endSwitch;
+
+    ctx->endBasicBlock = currentEndBb;
+
+    astToMirRet(switchMir);
+}
+
+static void visitBreakStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    csAssert0(ctx->endBasicBlock);
+    astToMirRet(insertInCurrentBlock(
+        ctx, makeMirJumpOp(ctx->mir, &node->loc, ctx->endBasicBlock, NULL)));
+}
+
+static void visitContinueStmt(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    csAssert0(ctx->loopUpdateBasicBlock);
+    astToMirRet(insertInCurrentBlock(
+        ctx,
+        makeMirJumpOp(ctx->mir, &node->loc, ctx->loopUpdateBasicBlock, NULL)));
+}
+
+static void visitVariableDecl(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    if (hasFlag(node, Comptime)) {
+        return;
+    }
+
+    if (hasFlag(node, TopLevelDecl)) {
+        astToMirRet(insertGlobalVariable(
+            ctx,
+            makeMirGlobalVariable(ctx->mir,
+                                  &node->loc,
+                                  node->varDecl.name,
+                                  convertAstToMir(visitor, node->varDecl.init),
+                                  node->type,
+                                  NULL)));
+    }
+    else {
+        MirNode *mirVar =
+            makeLocalVar(ctx, &node->loc, node->varDecl.name, node->type);
+        node->mir = mirVar;
+        if (node->varDecl.init) {
+            AstNode *init = node->varDecl.init;
+            insertInCurrentBlock(
+                ctx,
+                makeMirAssignOp(ctx->mir,
+                                &init->loc,
+                                makeMirLoadOp(ctx->mir,
+                                              &node->loc,
+                                              mirVar->AllocaOp.name,
+                                              mirVar,
+                                              NULL),
+                                convertAstToMir(visitor, init),
+                                NULL));
+        }
+        astToMirRet(mirVar);
+    }
+}
+
+static void visitExternDecl(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    AstNode *decl = node->externDecl.func;
+
+    if (nodeIs(decl, FuncDecl)) {
+        AstNode *param = decl->funcDecl.signature->params;
+        const Type *ret = decl->type->func.retType;
+        MirNodeList params = {};
+        for (; param; param = param->next) {
+            MirNode *mirParam = makeMirFunctionParam(
+                ctx->mir,
+                &param->loc,
+                param->funcParam.name,
+                makeMirTypeInfo(ctx->mir, &node->loc, param->type, NULL),
+                NULL);
+            param->mir = mirNodeListInsert(&params, mirParam);
+        }
+
+        astToMirRet(withMirFlags(makeMirFunction(ctx->mir,
+                                                 &node->loc,
+                                                 decl->funcDecl.name,
+                                                 params.first,
+                                                 ctx->basicBlocks.first,
+                                                 node->type,
+                                                 NULL),
+                                 mifExtern));
+    }
+    else if (nodeIs(decl, VarDecl)) {
+        astToMirRet(withMirFlags(makeMirGlobalVariable(ctx->mir,
+                                                       &decl->loc,
+                                                       decl->_namedNode.name,
+                                                       NULL,
+                                                       decl->type,
+                                                       NULL),
+                                 mifExtern));
+    }
+}
+
+static void visitFuncDecl(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    if (hasFlag(node, Abstract))
+        return;
+
+    u64 flags = mifNone;
+    if (hasFlag(node, Constructor))
+        flags |= mifConstructor;
+    if (findAttribute(node, S_inline))
+        flags |= mifInline;
+    else if (findAttribute(node, S_noinline))
+        flags |= mifNoInline;
+    const AstNode *opt = findAttribute(node, S_optimize);
+    if (opt) {
+        const AstNode *value = getAttributeArgument(NULL, NULL, opt, 0);
+        if (!nodeIs(value, IntegerLit)) {
+            logError(ctx->mir->L,
+                     &opt->loc,
+                     "invalid attribute argument expecting optimization level",
+                     NULL);
+        }
+        // TODO
+        flags |= mifNoOptimize;
+    }
+
+    const Type *ret = node->type->func.retType;
+    AstNode *param = node->funcDecl.signature->params;
+    MirNodeList params = {};
+    for (; param; param = param->next) {
+        param->mir = mirNodeListInsert(
+            &params,
+            makeMirFunctionParam(
+                ctx->mir,
+                &param->loc,
+                param->funcParam.name,
+                makeMirTypeInfo(ctx->mir, &node->loc, param->type, NULL),
+                NULL));
+    }
+
+    ctx->mirFnCtx = (MirFunctionContext){};
+    ctx->func = makeMirFunction(ctx->mir,
+                                &node->loc,
+                                node->funcDecl.name,
+                                params.first,
+                                ctx->basicBlocks.first,
+                                node->type,
+                                NULL);
+
+    if (!hasFlag(node, Extern)) {
+        ctx->mirFnCtx.uniqueNames = newHashTable(sizeof(Label));
+        mirNodeListInit(&ctx->basicBlocks);
+        MirNode *entry = insertBasicBlock(
+            ctx, makeMirBasicBlock(ctx->mir, &node->loc, "entry", NULL));
+        ctx->exitBasicBlock =
+            makeMirBasicBlock(ctx->mir, &node->loc, "exit", NULL);
+
+        ctx->currentBasicBlock = entry;
+
+        if (!typeIs(ret, Void)) {
+            ctx->returnVar = makeLocalVar(ctx, &node->loc, "_ret", ret);
+        }
+
+        node->mir = ctx->func;
+        astVisit(visitor, node->funcDecl.body);
+        if (!isMirBasicBlockTerminated(ctx->currentBasicBlock))
+            insertInCurrentBlock(ctx,
+                                 makeMirJumpOp(ctx->mir,
+                                               &ctx->currentBasicBlock->loc,
+                                               ctx->exitBasicBlock,
+                                               NULL));
+        ctx->currentBasicBlock = ctx->exitBasicBlock;
+        insertBasicBlock(ctx, ctx->exitBasicBlock);
+        insertInCurrentBlock(ctx, makeMirReturnOp(ctx->mir, &node->loc, ret));
+        ctx->func->Function.body = ctx->basicBlocks.first;
+
+        freeHashTable(&ctx->mirFnCtx.uniqueNames);
+    }
+    else {
+        flags |= mifExtern;
+    }
+
+    ctx->func = withMirFlags(ctx->func, flags);
+    astToMirRet(mirNodeListInsert(&ctx->globals, ctx->func));
+
+    ctx->mirFnCtx = (MirFunctionContext){};
+}
+
+static void visitProgram(AstVisitor *visitor, AstNode *node)
+{
+    AstToMirContext *ctx = getAstVisitorContext(visitor);
+    MirNodeList decls = {};
+    AstNode *decl = node->program.decls;
+    for (; decl; decl = decl->next) {
+        mirNodeListInsert(&decls, convertAstToMir(visitor, decl));
+    }
+    cstring name =
+        node->program.module ? node->program.module->moduleDecl.name : NULL;
+    astToMirRet(makeMirModule(
+        ctx->mir, &node->loc, name, node->program.path, decls.first));
+}
+
+#define newMirNode(TAG, BODY, ...)                                             \
+    makeMirNode(ctx,                                                           \
+                &(MirNode){.tag = mir##TAG,                                    \
+                           .loc = *loc,                                        \
+                           .TAG = BODY,                                        \
+                           .next = next,                                       \
+                           ##__VA_ARGS__})
+#define __B(...) {__VA_ARGS__}
+
+u64 mirCount(const MirNode *nodes)
+{
+    const MirNode *node = nodes;
+    u64 i = 0;
+    for (; node; node = node->next, i++)
+        ;
+    return i;
+}
+
+MirNode *makeMirNode(MirContext *ctx, MirNode *tmpl)
+{
+    MirNode *node = allocFromMemPool(ctx->pool, sizeof(MirNode));
+    *node = *tmpl;
+    return node;
+}
+
+MirNode *cloneMirNode(MirContext *ctx, const MirNode *node)
+{
+    MirNode *clone = allocFromMemPool(ctx->pool, sizeof(MirNode));
+    *clone = *node;
+    return clone;
+}
+
+MirNode *makeMirNullConst(MirContext *ctx,
+                          const FileLoc *loc,
+                          const Type *type,
+                          MirNode *next)
+{
+    return newMirNode(NullConst, {}, .type = type);
+}
+
+MirNode *makeMirBoolConst(MirContext *ctx,
+                          const FileLoc *loc,
+                          bool value,
+                          MirNode *next)
+{
+    return newMirNode(BoolConst,
+                      {.value = value},
+                      .type = ctx->types->primitiveTypes[prtBool]);
+}
+
+MirNode *makeMirCharConst(MirContext *ctx,
+                          const FileLoc *loc,
+                          char value,
+                          MirNode *next)
+{
+    return newMirNode(CharConst,
+                      {.value = value},
+                      .type = ctx->types->primitiveTypes[prtCChar]);
+}
+
+MirNode *makeMirUnsignedConst(MirContext *ctx,
+                              const FileLoc *loc,
+                              u64 value,
+                              const Type *type,
+                              MirNode *next)
+{
+    return newMirNode(
+        UnsignedConst, {.value = value}, .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirSignedConst(MirContext *ctx,
+                            const FileLoc *loc,
+                            i64 value,
+                            const Type *type,
+                            MirNode *next)
+{
+    return newMirNode(SignedConst, {.value = value}, .type = type);
+}
+
+MirNode *makeMirFloatConst(MirContext *ctx,
+                           const FileLoc *loc,
+                           f64 value,
+                           const Type *type,
+                           MirNode *next)
+{
+    return newMirNode(
+        FloatConst, {.value = value}, .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirStringConst(MirContext *ctx,
+                            const FileLoc *loc,
+                            cstring value,
+                            MirNode *next)
+{
+    return newMirNode(
+        StringConst, {.value = value}, .type = ctx->types->stringType);
+}
+
+MirNode *makeMirArrayConst(MirContext *ctx,
+                           const FileLoc *loc,
+                           MirNode *elems,
+                           u64 len,
+                           const struct Type *type,
+                           MirNode *next)
+{
+    return newMirNode(ArrayConst,
+                      __B(.elems = elems, .len = len),
+                      .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirStructConst(MirContext *ctx,
+                            const FileLoc *loc,
+                            MirNode *elems,
+                            u64 len,
+                            const struct Type *type,
+                            MirNode *next)
+{
+    return newMirNode(StructConst,
+                      __B(.elems = elems, .len = len),
+                      .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirAllocaOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         cstring name,
+                         const Type *type,
+                         MirNode *next)
+{
+    return newMirNode(
+        AllocaOp, {.name = name}, .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirLoadOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       cstring name,
+                       MirNode *var,
+                       MirNode *next)
+{
+    return newMirNode(LoadOp, __B(.name = name, .var = var), .type = var->type);
+}
+MirNode *makeMirAssignOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *lValue,
+                         MirNode *rValue,
+                         MirNode *next)
+{
+    return newMirNode(AssignOp,
+                      __B(.lValue = lValue, .rValue = rValue),
+                      .type = lValue->type);
+}
+MirNode *makeMirUnaryOp(MirContext *ctx,
+                        const FileLoc *loc,
+                        Operator op,
+                        MirNode *operand,
+                        MirNode *next)
+{
+    return newMirNode(
+        UnaryOp, __B(.op = op, .operand = operand), .type = operand->type);
+}
+
+MirNode *makeMirBinaryOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *lhs,
+                         Operator op,
+                         MirNode *rhs,
+                         const Type *type,
+                         MirNode *next)
+{
+    return newMirNode(BinaryOp,
+                      __B(.lhs = lhs, .op = op, .rhs = rhs),
+                      .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirCastOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *expr,
+                       MirNode *type,
+                       MirNode *next)
+{
+    return newMirNode(
+        CastOp, __B(.expr = expr, .type = type), .type = type->type);
+}
+
+MirNode *makeMirMoveOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *operand,
+                       MirNode *next)
+{
+    return newMirNode(MoveOp, __B(.operand = operand), .type = operand->type);
+}
+
+MirNode *makeMirCopyOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *operand,
+                       MirNode *next)
+{
+    return newMirNode(CopyOp, __B(.operand = operand), .type = operand->type);
+}
+
+MirNode *makeMirReferenceOfOp(MirContext *ctx,
+                              const FileLoc *loc,
+                              MirNode *operand,
+                              const struct Type *type,
+                              MirNode *next)
+{
+    return withMirFlags(newMirNode(ReferenceOfOp,
+                                   __B(.operand = operand),
+                                   .type = resolveUnThisUnwrapType(type)),
+                        mifReference);
+}
+
+MirNode *makeMirPointerOfOp(MirContext *ctx,
+                            const FileLoc *loc,
+                            MirNode *operand,
+                            const struct Type *type,
+                            MirNode *next)
+{
+    return withMirFlags(newMirNode(PointerOfOp,
+                                   __B(.operand = operand),
+                                   .type = resolveUnThisUnwrapType(type)),
+                        mifPointer);
+}
+
+MirNode *makeMirSizeofOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         const struct Type *type,
+                         MirNode *next)
+{
+    return newMirNode(SizeofOp,
+                      __B(.operand = makeMirTypeInfo(
+                              ctx, loc, resolveUnThisUnwrapType(type), NULL)),
+                      .type = type);
+}
+
+MirNode *makeMirZeromemOp(MirContext *ctx,
+                          const FileLoc *loc,
+                          MirNode *operand,
+                          MirNode *next)
+{
+    return newMirNode(
+        ZeromemOp, __B(.operand = operand), .type = operand->type);
+}
+
+MirNode *makeMirArrayInitOp(MirContext *ctx,
+                            const FileLoc *loc,
+                            MirNode *elems,
+                            u64 len,
+                            const struct Type *type,
+                            MirNode *next)
+{
+    return newMirNode(ArrayInitOp,
+                      __B(.elems = elems, .len = len),
+                      .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirStructInitOp(MirContext *ctx,
+                             const FileLoc *loc,
+                             MirNode *elems,
+                             u64 len,
+                             const struct Type *type,
+                             MirNode *next)
+{
+    return newMirNode(StructInitOp,
+                      __B(.elems = elems, .len = len),
+                      .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirIndexOp(MirContext *ctx,
+                        const FileLoc *loc,
+                        MirNode *target,
+                        MirNode *index,
+                        MirNode *next)
+{
+    return newMirNode(IndexOp,
+                      __B(.target = target, .index = index),
+                      .type = typeGetElement(ctx, target->type));
+}
+
+MirNode *makeMirMemberOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *target,
+                         u64 index,
+                         MirNode *next)
+{
+    return newMirNode(MemberOp,
+                      __B(.target = target, .index = index),
+                      .type = typeGetMember(target->type, index));
+}
+
+MirNode *makeMirCallOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *func,
+                       MirNode *args,
+                       MirNode *panic,
+                       MirNode *next)
+{
+    return newMirNode(CallOp,
+                      __B(.func = func, .args = args, .panic = panic),
+                      .type = typeReturnType(func->type));
+}
+
+MirNode *makeMirJumpOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *bb,
+                       MirNode *next)
+{
+    return newMirNode(JumpOp, __B(.bb = bb), .type = ctx->types->voidType);
+}
+
+MirNode *makeMirIfOp(MirContext *ctx,
+                     const FileLoc *loc,
+                     MirNode *cond,
+                     MirNode *ifTrue,
+                     MirNode *ifFalse,
+                     MirNode *next)
+{
+    return newMirNode(IfOp,
+                      __B(.cond = cond, .ifTrue = ifTrue, .ifFalse = ifFalse),
+                      .type = ifTrue->type);
+}
+
+MirNode *makeMirCaseOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *matches,
+                       MirNode *body,
+                       MirNode *next)
+{
+    return newMirNode(
+        CaseOp, __B(.matches = matches, .body = body), .type = body->type);
+}
+
+MirNode *makeMirSwitchOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *cond,
+                         MirNode *cases,
+                         MirNode *next)
+{
+    return newMirNode(SwitchOp,
+                      __B(.cond = cond, .cases = cases),
+                      .type = ctx->types->voidType);
+}
+
+MirNode *makeMirReturnOp(MirContext *ctx, const FileLoc *loc, const Type *type)
+{
+    MirNode *next = NULL;
+    return newMirNode(ReturnOp, {}, .type = type);
+}
+
+MirNode *makeMirPanicOp(MirContext *ctx, const FileLoc *loc)
+{
+    MirNode *next = NULL;
+    return newMirNode(PanicOp, {});
+}
+
+MirNode *makeMirGlobalVariable(MirContext *ctx,
+                               const FileLoc *loc,
+                               cstring name,
+                               MirNode *init,
+                               const Type *type,
+                               MirNode *next)
+{
+    return newMirNode(
+        GlobalVariable, __B(.name = name, .init = init), .type = type);
+}
+
+MirNode *makeMirTypeInfo(MirContext *ctx,
+                         const FileLoc *loc,
+                         const Type *type,
+                         MirNode *next)
+{
+    return newMirNode(TypeInfo, {.type = type}, .type = type);
+}
+
+MirNode *makeMirAsmOperand(MirContext *ctx,
+                           const FileLoc *loc,
+                           cstring constraint,
+                           struct MirNode *operand,
+                           MirNode *next)
+{
+    return newMirNode(AsmOperand,
+                      __B(.constraint = constraint, .operand = operand),
+                      .type = operand->type);
+}
+
+MirNode *makeMirInlineAssembly(MirContext *ctx,
+                               const FileLoc *loc,
+                               cstring text,
+                               MirNode *outputs,
+                               MirNode *inputs,
+                               MirNode *clobbers,
+                               const Type *type,
+                               MirNode *next)
+{
+    return newMirNode(InlineAssembly,
+                      __B(.text = text,
+                          .outputs = outputs,
+                          .inputs = inputs,
+                          .clobbers = clobbers),
+                      .type = type);
+}
+
+MirNode *makeMirBasicBlock(MirContext *ctx,
+                           const FileLoc *loc,
+                           cstring name,
+                           MirNode *next)
+{
+    return newMirNode(
+        BasicBlock, __B(.name = name), .type = ctx->types->voidType);
+}
+
+MirNode *makeMirFunctionParam(MirContext *ctx,
+                              const FileLoc *loc,
+                              cstring name,
+                              MirNode *type,
+                              MirNode *next)
+{
+    return newMirNode(
+        FunctionParam, __B(.name = name, .type = type), .type = type->type);
+}
+
+MirNode *makeMirFunction(MirContext *ctx,
+                         const FileLoc *loc,
+                         cstring name,
+                         MirNode *params,
+                         MirNode *body,
+                         const struct Type *type,
+                         MirNode *next)
+{
+    return newMirNode(Function,
+                      __B(.name = name, .params = params, .body = body),
+                      .type = resolveUnThisUnwrapType(type));
+}
+
+MirNode *makeMirModule(MirContext *ctx,
+                       const FileLoc *loc,
+                       cstring name,
+                       cstring path,
+                       MirNode *decls)
+{
+    MirNode *next = NULL;
+    return newMirNode(
+        Module, __B(.name = name, .path = path, .decls = decls), .type = NULL);
+}
+
+#undef __B
+#undef newMirNode
+
+MirNode *mirNodeGetLastNode(MirNode *node)
+{
+    while (node && node->next)
+        node = node->next;
+    return node;
+}
+
+MirNode *mirNodeListInsert(MirNodeList *list, MirNode *node)
+{
+    if (node) {
+        if (list->first == NULL)
+            list->first = node;
+        else
+            list->last->next = node;
+        list->last = mirNodeGetLastNode(node);
+    }
+    return node;
+}
+
+void mirNodeListInit(MirNodeList *list)
+{
+    list->first = NULL;
+    list->last = NULL;
+}
+
+AstNode *astToMir(struct CompilerDriver *cc, AstNode *node)
+{
+    AstToMirContext context = {.mir = cc->mir};
+    // clang-format off
+    AstVisitor visitor = makeAstVisitor(&context, {
+        [astProgram] = visitProgram,
+        [astAsmOperand] = visitAsmOperand,
+        [astAsm] = visitInlineAssembly,
+        [astBackendCall] = visitBackendCallExpr,
+        [astIdentifier] = visitIdentifier,
+        [astIntegerLit] = visitIntegerLit,
+        [astNullLit] = visitNullLit,
+        [astBoolLit] = visitBoolLit,
+        [astCharLit] = visitCharLit,
+        [astFloatLit] = visitFloatLit,
+        [astStringLit] = visitStringLit,
+        [astArrayExpr] = visitArrayExpr,
+        [astBinaryExpr] = visitBinaryExpr,
+        [astAssignExpr] = visitAssignExpr,
+        [astTernaryExpr] = visitTernaryExpr,
+        [astUnaryExpr] = visitUnaryExpr,
+        [astTypedExpr] = visitTypedExpr,
+        [astCallExpr] = visitCallExpr,
+        [astCastExpr] = visitCastExpr,
+        [astGroupExpr] = visitGroupExpr,
+        [astStmtExpr] = visitStmtExpr,
+        [astMemberExpr] = visitMemberExpr,
+        [astPointerOf] = visitPointerOfExpr,
+        [astReferenceOf] = visitReferenceOfExpr,
+        [astIndexExpr] = visitIndexExpr,
+        [astFieldExpr] = visitFieldExpr,
+        [astStructExpr] = visitStructExpr,
+        [astTupleExpr] = visitTupleExpr,
+        [astUnionValueExpr] = visitUnionValue,
+        [astBlockStmt] = visitBlockStmt,
+        [astExprStmt] = visitExprStmt,
+        [astReturnStmt] = visitReturnStmt,
+        [astIfStmt] = visitIfStmt,
+        [astWhileStmt] = visitWhileStmt,
+        [astSwitchStmt] = visitSwitchStmt,
+        [astContinueStmt] = visitContinueStmt,
+        [astBreakStmt] = visitBreakStmt,
+        [astVarDecl] = visitVariableDecl,
+        [astExternDecl] = visitExternDecl,
+        [astFuncDecl] = visitFuncDecl,
+        [astMatchStmt] = astVisitSkip,
+        [astFuncParamDecl] = astVisitSkip,
+        [astCaseStmt] = astVisitSkip,
+        [astStructDecl] = astVisitSkip,
+        [astClassDecl] = astVisitSkip,
+        [astInterfaceDecl] = astVisitSkip,
+        [astUnionDecl] = astVisitSkip,
+        [astEnumDecl] = astVisitSkip,
+        [astTypeRef] = astVisitSkip,
+        [astTypeDecl] = astVisitSkip,
+        [astGenericDecl] = astVisitSkip,
+        [astImportDecl] = astVisitSkip,
+        [astMacroDecl] = astVisitSkip
+    }, .fallback = astVisitFallbackVisitAll);
+    // clang-format on
+
+    astVisit(&visitor, node);
+    if (hasErrors(cc->L))
+        return NULL;
+
+    return node;
+}

--- a/src/cxy/lang/middle/mir/node.h
+++ b/src/cxy/lang/middle/mir/node.h
@@ -1,0 +1,481 @@
+//
+// Created by Carter Mbotho on 2024-11-01.
+//
+
+#include <core/log.h>
+#include <core/mempool.h>
+
+#include "lang/frontend/flag.h"
+#include "lang/frontend/operator.h"
+
+#pragma once
+
+// clang-format off
+#define CXY_MIR_TAGS(f)             \
+    f(NullConst)                    \
+    f(BoolConst)                    \
+    f(CharConst)                    \
+    f(UnsignedConst)                \
+    f(SignedConst)                  \
+    f(FloatConst)                   \
+    f(StringConst)                  \
+    f(ArrayConst)                   \
+    f(StructConst)                  \
+    f(AllocaOp)                     \
+    f(LoadOp)                       \
+    f(AssignOp)                     \
+    f(CastOp)                       \
+    f(MoveOp)                       \
+    f(CopyOp)                       \
+    f(ReferenceOfOp)                \
+    f(PointerOfOp)                  \
+    f(DropOp)                       \
+    f(SizeofOp)                     \
+    f(ZeromemOp)                    \
+    f(UnaryOp)                      \
+    f(BinaryOp)                     \
+    f(ArrayInitOp)                  \
+    f(StructInitOp)                 \
+    f(IndexOp)                      \
+    f(MemberOp)                     \
+    f(CallOp)                       \
+    f(JumpOp)                       \
+    f(IfOp)                         \
+    f(CaseOp)                       \
+    f(SwitchOp)                     \
+    f(ReturnOp)                     \
+    f(PanicOp)                      \
+    f(GlobalVariable)               \
+    f(TypeInfo)                     \
+    f(AsmOperand)                   \
+    f(InlineAssembly)               \
+    f(BasicBlock)                   \
+    f(FunctionParam)                \
+    f(Function)                     \
+    f(Module)
+
+// clang-format on
+
+typedef enum MirTag {
+#define f(NAME, ...) mir##NAME,
+    CXY_MIR_TAGS(f)
+#undef f
+} MirTag;
+
+struct Type;
+
+typedef struct MirNode MirNode;
+
+typedef struct MirNodeList {
+    MirNode *first;
+    MirNode *last;
+} MirNodeList;
+
+struct MirNode {
+    struct MirNode *next;
+    struct MirNode *parent;
+    MirTag tag;
+    const struct Type *type;
+    FileLoc loc;
+    Flags flags;
+
+    union {
+        struct {
+        } NullConst;
+
+        struct {
+            bool value;
+        } BoolConst;
+
+        struct {
+            u32 value;
+        } CharConst;
+
+        union {
+            i64 value;
+        } SignedConst;
+        union {
+            u64 value;
+        } UnsignedConst;
+
+        struct {
+            f64 value;
+        } FloatConst;
+
+        struct {
+            u64 len;
+            cstring value;
+        } StringConst;
+
+        struct {
+            u64 len;
+            struct MirNode *elems;
+        } ArrayConst, StructConst;
+
+        struct {
+            cstring name;
+        } AllocaOp;
+
+        struct {
+            cstring name;
+            struct MirNode *var;
+        } LoadOp;
+
+        struct {
+            struct MirNode *lValue;
+            struct MirNode *rValue;
+        } AssignOp;
+
+        struct {
+            Operator op;
+            struct MirNode *operand;
+        } UnaryOp;
+
+        struct {
+            struct MirNode *lhs;
+            Operator op;
+            struct MirNode *rhs;
+        } BinaryOp;
+
+        struct {
+            struct MirNode *expr;
+            struct MirNode *type;
+        } CastOp;
+
+        struct {
+            struct MirNode *operand;
+        } MoveOp, CopyOp, ReferenceOfOp, PointerOfOp, DropOp;
+
+        struct {
+            struct MirNode *operand;
+        } ZeromemOp, SizeofOp;
+
+        struct {
+            u64 len;
+            struct MirNode *elems;
+        } ArrayInitOp, StructInitOp;
+
+        struct {
+            struct MirNode *target;
+            struct MirNode *index;
+        } IndexOp;
+
+        struct {
+            struct MirNode *target;
+            u64 index;
+        } MemberOp;
+
+        struct {
+            struct MirNode *func;
+            struct MirNode *args;
+            struct MirNode *panic;
+        } CallOp;
+
+        struct {
+            struct MirNode *bb;
+        } JumpOp;
+
+        struct {
+            struct MirNode *cond;
+            struct MirNode *ifTrue;
+            struct MirNode *ifFalse;
+        } IfOp;
+
+        struct {
+            struct MirNode *matches;
+            struct MirNode *body;
+        } CaseOp;
+
+        struct {
+            struct MirNode *cond;
+            struct MirNode *cases;
+            struct MirNode *def;
+        } SwitchOp;
+
+        struct {
+        } ReturnOp;
+
+        struct {
+        } PanicOp;
+
+        struct {
+            const struct Type *type;
+        } TypeInfo;
+
+        struct {
+            cstring constraint;
+            struct MirNode *operand;
+        } AsmOperand;
+
+        struct {
+            cstring text;
+            struct MirNode *outputs;
+            struct MirNode *inputs;
+            struct MirNode *clobbers;
+        } InlineAssembly;
+
+        struct {
+            cstring name;
+            cstring ns;
+            struct MirNode *init;
+        } GlobalVariable;
+
+        struct {
+            cstring name;
+            MirNodeList nodes;
+        } BasicBlock;
+
+        struct {
+            cstring name;
+            struct MirNode *type;
+        } FunctionParam;
+
+        struct {
+            cstring name;
+            cstring ns;
+            cstring container;
+            struct MirNode *params;
+            struct MirNode *body;
+        } Function;
+
+        struct {
+            cstring name;
+            cstring path;
+            struct MirNode *decls;
+        } Module;
+    };
+};
+
+typedef struct MirContext MirContext;
+
+static inline bool mirIs_(const MirNode *node, MirTag tag)
+{
+    return node && node->tag == tag;
+}
+#define mirIs(NODE, TAG) mirIs_((NODE), mir##TAG)
+
+static inline MirNode *withMirFlags(MirNode *node, u64 flags)
+{
+    node->flags |= flags;
+    return node;
+}
+
+u64 mirCount(const MirNode *nodes);
+
+MirNode *makeMirNode(MirContext *ctx, MirNode *tmpl);
+MirNode *cloneMirNode(MirContext *ctx, const MirNode *node);
+MirNode *makeMirNullConst(MirContext *ctx,
+                          const FileLoc *loc,
+                          const struct Type *type,
+                          MirNode *next);
+MirNode *makeMirBoolConst(MirContext *ctx,
+                          const FileLoc *loc,
+                          bool value,
+                          MirNode *next);
+
+MirNode *makeMirCharConst(MirContext *ctx,
+                          const FileLoc *loc,
+                          char value,
+                          MirNode *next);
+
+MirNode *makeMirUnsignedConst(MirContext *ctx,
+                              const FileLoc *loc,
+                              u64 value,
+                              const struct Type *type,
+                              MirNode *next);
+MirNode *makeMirSignedConst(MirContext *ctx,
+                            const FileLoc *loc,
+                            i64 value,
+                            const struct Type *type,
+                            MirNode *next);
+MirNode *makeMirFloatConst(MirContext *ctx,
+                           const FileLoc *loc,
+                           f64 value,
+                           const struct Type *type,
+                           MirNode *next);
+MirNode *makeMirStringConst(MirContext *ctx,
+                            const FileLoc *loc,
+                            cstring value,
+                            MirNode *next);
+MirNode *makeMirArrayConst(MirContext *ctx,
+                           const FileLoc *loc,
+                           MirNode *elems,
+                           u64 len,
+                           const struct Type *type,
+                           MirNode *next);
+MirNode *makeMirStructConst(MirContext *ctx,
+                            const FileLoc *loc,
+                            MirNode *elems,
+                            u64 len,
+                            const struct Type *type,
+                            MirNode *next);
+
+MirNode *makeMirAllocaOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         cstring name,
+                         const struct Type *type,
+                         MirNode *next);
+MirNode *makeMirLoadOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       cstring name,
+                       MirNode *var,
+                       MirNode *next);
+MirNode *makeMirAssignOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *lValue,
+                         MirNode *rValue,
+                         MirNode *next);
+MirNode *makeMirUnaryOp(MirContext *ctx,
+                        const FileLoc *loc,
+                        Operator op,
+                        MirNode *operand,
+                        MirNode *next);
+MirNode *makeMirBinaryOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *lhs,
+                         Operator op,
+                         MirNode *rhs,
+                         const struct Type *type,
+                         MirNode *next);
+MirNode *makeMirCastOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *expr,
+                       MirNode *type,
+                       MirNode *next);
+MirNode *makeMirMoveOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *operand,
+                       MirNode *next);
+MirNode *makeMirCopyOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *operand,
+                       MirNode *next);
+MirNode *makeMirReferenceOfOp(MirContext *ctx,
+                              const FileLoc *loc,
+                              MirNode *operand,
+                              const struct Type *type,
+                              MirNode *next);
+MirNode *makeMirPointerOfOp(MirContext *ctx,
+                            const FileLoc *loc,
+                            MirNode *operand,
+                            const struct Type *type,
+                            MirNode *next);
+MirNode *makeMirSizeofOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         const struct Type *type,
+                         MirNode *next);
+MirNode *makeMirZeromemOp(MirContext *ctx,
+                          const FileLoc *loc,
+                          MirNode *operand,
+                          MirNode *next);
+
+MirNode *makeMirArrayInitOp(MirContext *ctx,
+                            const FileLoc *loc,
+                            MirNode *elems,
+                            u64 len,
+                            const struct Type *type,
+                            MirNode *next);
+MirNode *makeMirStructInitOp(MirContext *ctx,
+                             const FileLoc *loc,
+                             MirNode *elems,
+                             u64 len,
+                             const struct Type *type,
+                             MirNode *next);
+MirNode *makeMirIndexOp(MirContext *ctx,
+                        const FileLoc *loc,
+                        MirNode *target,
+                        MirNode *index,
+                        MirNode *next);
+MirNode *makeMirMemberOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *target,
+                         u64 index,
+                         MirNode *next);
+MirNode *makeMirCallOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *func,
+                       MirNode *args,
+                       MirNode *panic,
+                       MirNode *next);
+MirNode *makeMirJumpOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *bb,
+                       MirNode *next);
+MirNode *makeMirIfOp(MirContext *ctx,
+                     const FileLoc *loc,
+                     MirNode *cond,
+                     MirNode *ifTrue,
+                     MirNode *ifFalse,
+                     MirNode *next);
+MirNode *makeMirCaseOp(MirContext *ctx,
+                       const FileLoc *loc,
+                       MirNode *matches,
+                       MirNode *body,
+                       MirNode *next);
+MirNode *makeMirSwitchOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         MirNode *cond,
+                         MirNode *cases,
+                         MirNode *next);
+
+MirNode *makeMirReturnOp(MirContext *ctx,
+                         const FileLoc *loc,
+                         const struct Type *type);
+
+MirNode *makeMirPanicOp(MirContext *ctx, const FileLoc *loc);
+
+MirNode *makeMirTypeInfo(MirContext *ctx,
+                         const FileLoc *loc,
+                         const struct Type *type,
+                         MirNode *next);
+
+MirNode *makeMirAsmOperand(MirContext *ctx,
+                           const FileLoc *loc,
+                           cstring constraint,
+                           struct MirNode *operand,
+                           MirNode *next);
+
+MirNode *makeMirInlineAssembly(MirContext *ctx,
+                               const FileLoc *loc,
+                               cstring text,
+                               MirNode *outputs,
+                               MirNode *inputs,
+                               MirNode *clobbers,
+                               const struct Type *type,
+                               MirNode *next);
+
+MirNode *makeMirGlobalVariable(MirContext *ctx,
+                               const FileLoc *loc,
+                               cstring name,
+                               MirNode *init,
+                               const struct Type *type,
+                               MirNode *next);
+
+MirNode *makeMirBasicBlock(MirContext *ctx,
+                           const FileLoc *loc,
+                           cstring name,
+                           MirNode *next);
+
+MirNode *makeMirFunctionParam(MirContext *ctx,
+                              const FileLoc *loc,
+                              cstring name,
+                              MirNode *type,
+                              MirNode *next);
+
+MirNode *makeMirFunction(MirContext *ctx,
+                         const FileLoc *loc,
+                         cstring name,
+                         MirNode *params,
+                         MirNode *body,
+                         const struct Type *type,
+                         MirNode *next);
+
+MirNode *makeMirModule(MirContext *ctx,
+                       const FileLoc *loc,
+                       cstring name,
+                       cstring path,
+                       MirNode *decls);
+
+void mirNodeListInit(MirNodeList *list);
+MirNode *mirNodeGetLastNode(MirNode *node);
+MirNode *mirNodeListInsert(MirNodeList *list, MirNode *node);

--- a/src/cxy/lang/middle/mir/print.c
+++ b/src/cxy/lang/middle/mir/print.c
@@ -1,0 +1,362 @@
+//
+// Created by Carter Mbotho on 2024-11-06.
+//
+#include "context.h"
+#include "driver/driver.h"
+#include "node.h"
+
+typedef struct {
+    FormatState state;
+} PrintContext;
+
+static void printMirNode(PrintContext *ctx, const MirNode *node);
+
+static void printManyMirNodes(PrintContext *ctx,
+                              const MirNode *nodes,
+                              cstring start,
+                              cstring sep,
+                              cstring end)
+{
+    if (start)
+        format(&ctx->state, start, NULL);
+    for (const MirNode *it = nodes; it; it = it->next) {
+        printMirNode(ctx, it);
+        if (sep && it->next)
+            format(&ctx->state, sep, NULL);
+    }
+    if (end)
+        format(&ctx->state, end, NULL);
+}
+
+static void printMirNode(PrintContext *ctx, const MirNode *node)
+{
+    switch (node->tag) {
+    case mirNullConst:
+        printKeyword(&ctx->state, "null");
+        return;
+    case mirBoolConst:
+        printKeyword(&ctx->state, node->BoolConst.value ? "true" : "false");
+        return;
+    case mirCharConst:
+        format(&ctx->state,
+               "{$}'{cE}'{$}",
+               (FormatArg[]){{.style = stringStyle},
+                             {.c = node->CharConst.value},
+                             {.style = resetStyle}});
+        return;
+    case mirUnsignedConst:
+        format(&ctx->state,
+               "{$}{u64}:{s}{$}",
+               (FormatArg[]){{.style = literalStyle},
+                             {.u64 = node->UnsignedConst.value},
+                             {.s = node->type->name},
+                             {.style = resetStyle}});
+        return;
+    case mirSignedConst:
+        format(&ctx->state,
+               "{$}{i64}:{s}{$}",
+               (FormatArg[]){{.style = literalStyle},
+                             {.i64 = node->SignedConst.value},
+                             {.s = node->type->name},
+                             {.style = resetStyle}});
+        return;
+    case mirFloatConst:
+        format(&ctx->state,
+               "{$}{f64}:{s}{$}",
+               (FormatArg[]){{.style = literalStyle},
+                             {.f64 = node->FloatConst.value},
+                             {.s = node->type->name},
+                             {.style = resetStyle}});
+        return;
+    case mirStringConst:
+        format(&ctx->state,
+               "{$}\"{sE}\"{$}",
+               (FormatArg[]){{.style = stringStyle},
+                             {.s = node->StringConst.value},
+                             {.style = resetStyle}});
+        return;
+    case mirArrayConst:
+    case mirStructConst:
+        format(&ctx->state,
+               "({$}const{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        // fall-through
+    case mirArrayInitOp:
+    case mirStructInitOp:
+        format(&ctx->state, mirIs(node, ArrayConst) ? "[" : "{{", NULL);
+        for (const MirNode *it = node->ArrayConst.elems; it; it = it->next) {
+            printMirNode(ctx, it);
+            if (it->next)
+                format(&ctx->state, ", ", NULL);
+        }
+        format(&ctx->state, mirIs(node, ArrayConst) ? "]" : "}", NULL);
+        if (mirIs(node, ArrayInitOp) || mirIs(node, StructInitOp))
+            return;
+        break;
+    case mirAllocaOp:
+        format(&ctx->state,
+               "({$}alloca{$} {s}",
+               (FormatArg[]){{.style = keywordStyle},
+                             {.style = resetStyle},
+                             {.s = node->AllocaOp.name}});
+        break;
+    case mirLoadOp:
+        format(&ctx->state, "{s}", (FormatArg[]){{.s = node->LoadOp.name}});
+        return;
+    case mirAssignOp:
+        appendString(&ctx->state, "(`=` ");
+        printMirNode(ctx, node->AssignOp.lValue);
+        appendString(&ctx->state, " ");
+        printMirNode(ctx, node->AssignOp.rValue);
+        break;
+    case mirCastOp:
+        format(&ctx->state,
+               "({$}cast{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->CastOp.expr);
+        appendString(&ctx->state, " ");
+        printMirNode(ctx, node->CastOp.type);
+        break;
+    case mirMoveOp:
+        appendString(&ctx->state, "(&& ");
+        printMirNode(ctx, node->MoveOp.operand);
+        break;
+    case mirCopyOp:
+        format(&ctx->state,
+               "({$}copy{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->CopyOp.operand);
+        break;
+    case mirReferenceOfOp:
+        appendString(&ctx->state, "(`&` ");
+        printMirNode(ctx, node->ReferenceOfOp.operand);
+        break;
+    case mirPointerOfOp:
+        format(&ctx->state,
+               "({$}ptrof{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->PointerOfOp.operand);
+        break;
+    case mirDropOp:
+        format(&ctx->state,
+               "({$}drop{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->DropOp.operand);
+        break;
+    case mirSizeofOp:
+        format(&ctx->state,
+               "({$}sizeof{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->SizeofOp.operand);
+        break;
+    case mirZeromemOp:
+        format(&ctx->state,
+               "({$}zeromem{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->ZeromemOp.operand);
+        break;
+    case mirUnaryOp:
+        format(&ctx->state,
+               "(`{s}` ",
+               (FormatArg[]){{.s = getUnaryOpString(node->UnaryOp.op)}});
+        printMirNode(ctx, node->UnaryOp.operand);
+        break;
+    case mirBinaryOp:
+        format(&ctx->state,
+               "(`{s}` ",
+               (FormatArg[]){{.s = getBinaryOpString(node->BinaryOp.op)}});
+        printMirNode(ctx, node->BinaryOp.lhs);
+        appendString(&ctx->state, " ");
+        printMirNode(ctx, node->BinaryOp.rhs);
+        break;
+    case mirIndexOp:
+        appendString(&ctx->state, "(`[]` ");
+        printMirNode(ctx, node->IndexOp.target);
+        appendString(&ctx->state, " ");
+        printMirNode(ctx, node->IndexOp.index);
+        break;
+    case mirMemberOp:
+        appendString(&ctx->state, "(`.` ");
+        printMirNode(ctx, node->MemberOp.target);
+        format(&ctx->state,
+               " {u64}",
+               (FormatArg[]){{.u64 = node->MemberOp.index}});
+        break;
+    case mirCallOp:
+        //(call Hello_hello greeter "Bonjour" @panic)
+        format(&ctx->state,
+               "({$}call{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->CallOp.func);
+        for (const MirNode *it = node->CallOp.args; it; it = it->next) {
+            format(&ctx->state, " ", NULL);
+            printMirNode(ctx, it);
+            if (it->next)
+                format(&ctx->state, " ", NULL);
+        }
+        break;
+    case mirJumpOp:
+        // (jmp @label)
+        format(&ctx->state,
+               "({$}jmp{$} @{s}",
+               (FormatArg[]){{.style = keywordStyle},
+                             {.style = resetStyle},
+                             {.s = node->JumpOp.bb->BasicBlock.name}});
+        break;
+    case mirIfOp:
+        // (if cond @then @otherwise)
+        format(&ctx->state,
+               "({$}if{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->IfOp.cond);
+        format(&ctx->state,
+               " @{s} @{s}",
+               (FormatArg[]){{.s = node->IfOp.ifTrue->BasicBlock.name},
+                             {.s = node->IfOp.ifFalse->BasicBlock.name}});
+        break;
+    case mirSwitchOp:
+        // (switch cond [1 @case1] [2 @case2] @def)
+        format(&ctx->state,
+               "({$}switch{$}",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printMirNode(ctx, node->SwitchOp.cond);
+        for (const MirNode *it = node->SwitchOp.cases; it; it = it->next) {
+            if (mirIs(it->CaseOp.matches, UnsignedConst))
+                format(&ctx->state,
+                       " [{u64} @{s}]",
+                       (FormatArg[]){
+                           {.u64 = it->CaseOp.matches->UnsignedConst.value},
+                           {.s = it->CaseOp.body->BasicBlock.name}});
+            else
+                format(&ctx->state,
+                       " [{i64} @{s}]",
+                       (FormatArg[]){
+                           {.i64 = it->CaseOp.matches->SignedConst.value},
+                           {.s = it->CaseOp.body->BasicBlock.name}});
+        }
+        format(&ctx->state,
+               " @{s}",
+               (FormatArg[]){{.s = node->SwitchOp.def->BasicBlock.name}});
+        break;
+
+    case mirReturnOp:
+        // (return expr)
+        format(&ctx->state,
+               "({$}return{$}",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        break;
+    case mirPanicOp:
+        // (panic expr)
+        format(&ctx->state,
+               "({$}panic{$}",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        break;
+    case mirGlobalVariable:
+        format(&ctx->state,
+               "({$}var{$} {s}",
+               (FormatArg[]){{.style = keywordStyle},
+                             {.style = resetStyle},
+                             {.s = node->GlobalVariable.name}});
+        if (node->GlobalVariable.init) {
+            printUtf8(&ctx->state, ' ', false);
+            printMirNode(ctx, node->GlobalVariable.init);
+        }
+        break;
+    case mirAsmOperand:
+        format(&ctx->state,
+               "({$}\"{s}\"{$} ",
+               (FormatArg[]){{.style = stringStyle},
+                             {.s = node->AsmOperand.constraint},
+                             {.style = resetStyle}});
+        printMirNode(ctx, node->AsmOperand.operand);
+        format(&ctx->state, ")", NULL);
+        break;
+    case mirInlineAssembly:
+        format(&ctx->state,
+               "({$}asm{$} ",
+               (FormatArg[]){{.style = keywordStyle}, {.style = resetStyle}});
+        printAssemblyString(&ctx->state, node->InlineAssembly.text);
+        format(&ctx->state, "{>}\n", NULL);
+        printManyMirNodes(ctx, node->InlineAssembly.outputs, "(", " ", ")");
+        format(&ctx->state, "\n", NULL);
+        printManyMirNodes(ctx, node->InlineAssembly.inputs, "(", " ", ")");
+        format(&ctx->state, "\n", NULL);
+        printManyMirNodes(ctx, node->InlineAssembly.clobbers, "(", " ", ")");
+        format(&ctx->state, "{<}\n", NULL);
+        break;
+    case mirBasicBlock:
+        format(&ctx->state,
+               "({$}:{s}{$}",
+               (FormatArg[]){{.style = {STYLE_BOLD, COLOR_NORMAL}},
+                             {.s = node->BasicBlock.name},
+                             {.style = resetStyle}});
+        if (node->BasicBlock.nodes.first) {
+            format(&ctx->state, "{>}\n", NULL);
+            printManyMirNodes(
+                ctx, node->BasicBlock.nodes.first, NULL, "\n", NULL);
+            format(&ctx->state, "{<}\n", NULL);
+        }
+        break;
+    case mirFunctionParam:
+        format(
+            &ctx->state, "({s}: ", (FormatArg[]){{.s = node->Function.name}});
+        printMirNode(ctx, node->FunctionParam.type);
+        break;
+    case mirFunction:
+        format(&ctx->state,
+               "({$}func{$}{>}\n",
+               (FormatArg[]){{.style = {STYLE_BOLD, COLOR_NORMAL}},
+                             {.style = resetStyle}});
+        format(&ctx->state, "{s}\n", (FormatArg[]){{.s = node->Function.name}});
+        printManyMirNodes(ctx, node->Function.params, "(", " ", ")");
+        if (!(node->flags & mifExtern)) {
+            format(&ctx->state, "\n", NULL);
+            for (const MirNode *it = node->Function.body; it; it = it->next) {
+                printMirNode(ctx, it);
+                if (it->next)
+                    format(&ctx->state, "\n", NULL);
+            }
+        }
+        format(&ctx->state, "{<}\n", NULL);
+        break;
+    case mirModule:
+        printManyMirNodes(ctx, node->Module.decls, NULL, "\n", NULL);
+        break;
+    case mirTypeInfo:
+        format(&ctx->state,
+               "({$}typeinfo{$} ",
+               (FormatArg[]){{.style = {STYLE_BOLD, COLOR_NORMAL}},
+                             {.style = resetStyle}});
+        printType(&ctx->state, node->TypeInfo.type);
+        break;
+    default:
+        break;
+    }
+
+    format(&ctx->state, ")", NULL);
+}
+
+AstNode *dumpMir(CompilerDriver *driver, AstNode *node)
+{
+    Options *opts = &driver->options;
+    FILE *output = stdout;
+    PrintContext context = {};
+    csAssert0(node->mir);
+    if (opts->output) {
+        context.state = newFormatState("  ", true);
+        output = fopen(opts->output, "w");
+        csAssert0(output);
+    }
+    else {
+        context.state = newFormatState("  ", false);
+    }
+
+    printMirNode(&context, node->mir);
+    writeFormatState(&context.state, output);
+
+    if (opts->output) {
+        fclose(output);
+    }
+    freeFormatState(&context.state);
+    return node;
+}

--- a/src/cxy/lang/middle/sema/builtins.c
+++ b/src/cxy/lang/middle/sema/builtins.c
@@ -479,8 +479,12 @@ static void implementDestructorForwardFunction(AstVisitor *visitor,
         NULL,
         NULL);
 
-    fwd->funcDecl.body =
-        makeExprStmt(ctx->pool, &fwd->loc, flgNone, call, NULL, NULL);
+    fwd->funcDecl.body = makeBlockStmt(
+        ctx->pool,
+        &fwd->loc,
+        makeExprStmt(ctx->pool, &fwd->loc, flgNone, call, NULL, NULL),
+        NULL,
+        NULL);
 }
 
 static void implementHashFunction(AstVisitor *visitor,

--- a/src/cxy/lang/middle/sema/path.c
+++ b/src/cxy/lang/middle/sema/path.c
@@ -149,7 +149,7 @@ static const Type *checkBasePathElement(AstVisitor *visitor,
                            : enclosure->type;
         }
         else if (keyword == S_This) {
-            return enclosure->structDecl.thisType;
+            return node->type = enclosure->structDecl.thisType;
         }
         unreachable("unsupported keyword");
     }

--- a/src/cxy/lang/operations.h
+++ b/src/cxy/lang/operations.h
@@ -27,7 +27,8 @@ AstNode *collectAst(CompilerDriver *driver, AstNode *node);
 AstNode *backendDumpIR(CompilerDriver *driver, AstNode *node);
 AstNode *simplifyAst(CompilerDriver *driver, AstNode *node);
 AstNode *lowerAstNode(CompilerDriver *driver, AstNode *node);
-
+AstNode *astToMir(CompilerDriver *driver, AstNode *node);
+AstNode *dumpMir(CompilerDriver *driver, AstNode *node);
 #ifdef __cplusplus
 }
 #endif

--- a/src/cxy/runtime/builtins.cxy
+++ b/src/cxy/runtime/builtins.cxy
@@ -210,17 +210,19 @@ pub struct __Optional[T] {
     #if (T.isClass || T.hasReferenceMembers ) {
 
         func `destructor`() {
-            #if (T.isClass)
-                #if (defined __DEBUG && defined TRACE_MEMORY)
-                    __smart_ptr_drop_trace(val !: sptr, __SrcLoc{file: file!, line: line!})
+            if (ok) {
+                #if (T.isClass)
+                    #if (defined __DEBUG && defined TRACE_MEMORY)
+                        __smart_ptr_drop_trace(val !: sptr, __SrcLoc{file: file!, line: line!})
+                    else
+                        __smart_ptr_drop(val !: sptr)
+                else #if (T.isTuple)
+                    __tuple_dctor(&val)
+                else #if (T.isUnion)
+                    __union_dctor(&val)
                 else
-                    __smart_ptr_drop(val !: sptr)
-            else #if (T.isTuple)
-                __tuple_dctor(&val)
-            else #if (T.isUnion)
-                __union_dctor(&val)
-            else
-                val.op__destructor()
+                    val.op__destructor()
+            }
         }
     }
 

--- a/src/cxy/stdlib/fserver.cxy
+++ b/src/cxy/stdlib/fserver.cxy
@@ -14,7 +14,7 @@ import "sys/mman.h" as vmem
 import "sys/syslimits.h" as limits // for PATH_MAX! macro
 
 #if (!defined CXY_FILE_SERVER_ROUTE) {
-    macro CXY_FILE_SERVER_ROUTE "/1511d5908a7811e790ed6f6e6c696e65"
+    macro CXY_FILE_SERVER_ROUTE "/www"
 }
 
 pub struct Config {

--- a/src/cxy/stdlib/trie.cxy
+++ b/src/cxy/stdlib/trie.cxy
@@ -78,11 +78,10 @@ pub class Trie[Data] {
         for (var i: 0..len) {
             var child = node.get(prefix.[i]);
             if (!child)
-                continue
+                break
 
             node = *child;
             if (node.data) {
-
                 found = (i+1, *node.data)
             }
         }

--- a/src/tools/mem-analysis.rb
+++ b/src/tools/mem-analysis.rb
@@ -45,11 +45,10 @@ File.readlines(ARGV[0], chomp: true).each do |line|
         mem[addr][:freed] = true
     end
 end
+
 sorted = mem.sort{ |(_, a), (_, b)| b[:refs] <=> a[:refs] }.each{ |addr, info|
-    if not info[:freed]
-        puts "#{addr} @ #{info[:loc]}"
-        puts "    refs: #{info[:refs]}, drop: #{info[:drop]}, get: #{info[:get]}"
-    end
+    puts "#{addr} @ #{info[:loc]}"
+    puts "    refs: #{info[:refs]}, drop: #{info[:drop]}, get: #{info[:get]}"
 }
 
 if mem.key?(show)


### PR DESCRIPTION
Initial mir implementation. This would be followed by a refactor which makes use of this mir.
Currently mir is always generated but not used. It can be viewed with `--print-ir` of `dev` command.