### PR TITLE
Add support for an SSL socket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ set(CXY_MIDDLE_SOURCES
         src/cxy/lang/middle/eval/member.c
         src/cxy/lang/middle/eval/path.c
         src/cxy/lang/middle/eval/unary.c
+        src/cxy/lang/middle/eval/xform.c
 
         src/cxy/lang/middle/bind/bind.c
         src/cxy/lang/middle/bind/discover.c

--- a/benchmarks/nbodies.cxy
+++ b/benchmarks/nbodies.cxy
@@ -155,7 +155,7 @@ pub func main() {
 
     bodies.[0].offsetMomentum(px, py, pz);
 
-    for(const i: 0:i32..50000000) {
+    for(const i: 0 as i32..50000000) {
         bodiesAdvance(bodies, <u64>5, 1.0e-5);
     }
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -3,4 +3,4 @@ FROM ubuntu:latest AS builder
 # Install packages
 RUN apt-get -y update && apt-get -y upgrade
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing cmake \
-  clang llvm llvm-dev libclang-dev clang-format gdb
+  clang llvm llvm-dev libclang-dev clang-format gdb openssl libssl-dev

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -34,7 +34,7 @@ can be bound to a desired type using the `:<type>` operator.
 'a'
 '\n' // escaped character
 '☺️' // wide character
-'!':char // bound to type char
+'! ' as char // bound to type char
 ```
 
 ### Integers
@@ -48,7 +48,7 @@ fit the integer literal. If a specific type is desired, the literal can be bound
 0o77 // octal
 0xaf // hex
 
-100:i64 // Bound to type i64
+100 as i64 // Bound to type i64
 ```
 
 ### Float Literals
@@ -60,7 +60,7 @@ to the type.
 0.00    // float
 1e10    // exponential
 1e-10   // exponential
-1.32:f32  // bound to f32
+1.32 as f32  // bound to f32
 ```
 
 ### String Literals
@@ -179,7 +179,7 @@ func show(nums: [i32]) {
 }
 
 // Uses array literals (discussed in expressions section) to initialize an array
-var a:[i32, 3] = [ 0:i32, 1, 2] ;
+var a:[i32, 3] = [ 0 as i32, 1, 2] ;
 // Compiler will create a slice of the array
 show(a)
 
@@ -215,7 +215,7 @@ memory address other variables.
 * Arrays and strings are considered pointer types
 
 ```c
-var x = 100:u32;
+var x = 100 as u32;
 // getting the address of a variable
 var y: ^u32 = ptrof x;
 var s = "hello";
@@ -282,7 +282,7 @@ A tagged union is a list of types seperated by the `|` character that a variable
   value stored on the union variable.
 
 ```c
-var a: i32|string = 10:i32;
+var a: i32|string = 10 as i32;
 a = "Hello World";
 
 var b = <string>a; // Ok since string is in the union i32|string

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -170,7 +170,7 @@ exception AgeError(msg: String) => msg.str()
 
 struct User {
     - name: String;
-    - age = 16:i32;
+    - age = 16 as i32;
     func `init`(name: String) { this.name = &&name }
 
     func drink() : !void {

--- a/docs/stdlib/json.md
+++ b/docs/stdlib/json.md
@@ -76,7 +76,7 @@ class Colour {
 
 @[json]
 struct User {
-    age = 0:u32
+    age = 0 as u32
     name: String = null
     eyes = Colour()
 }

--- a/examples/add.c
+++ b/examples/add.c
@@ -7,7 +7,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <copyfile.h>
+#include <openssl/evp.h>
+# include <openssl/err.h>
+# include <openssl/ssl.h>
 int main(int argc, char *argv[])
 {
-    struct tm tm;
+    TLSv1_2_client_method
 }

--- a/examples/hello.cxy
+++ b/examples/hello.cxy
@@ -1,18 +1,20 @@
-import "stdlib/os.cxy"
+
 import "stdlib/json.cxy"
 
 @json
 struct User {
-    name: String = null;
+    name: String  = null;
     age: i32 = 0;
 
-    const func `str`(os: &OutputStream) {
-        os << "{ name: " << name << ", age: " << age << " }"
+    func `init`(){}
+
+    const func `str`(os: OutputStream) {
+        os << "User{ " << name << ", " << age << "}"
     }
 }
 
-func main(): !i32 {
-   var str = os.readAll("hello.json");
-   var user = json.fromString[User](&str);
-   println(user)
+func main(): !void {
+    var j = "{\"name\": \"John\", \"age\": 100, \"loc\": {\"city\": \"Vancouver\", \"ids\": [100, 100.9000, null, false, true, \"\", {}]}}".S;
+    var user = json.fromString[User](&j);
+    println(user)
 }

--- a/examples/server.cxy
+++ b/examples/server.cxy
@@ -9,7 +9,7 @@ func handleConnection(sock: TcpSocket) {
         if (len) {
             sock.send("You said: ")
             sock.sendBuffer(buffer, *len)
-            if ((buffer.[0] == 'Q':char) && (buffer.[1] == 'U':char)) {
+            if ((buffer.[0] == 'Q ' as char) && (buffer.[1] == 'U ' as char)) {
                 // Quit signal
                 sock.close()
             }

--- a/src/cxy/lang/frontend/ast.c
+++ b/src/cxy/lang/frontend/ast.c
@@ -2120,6 +2120,11 @@ AstNode *cloneAstNode(CloneAstConfig *config, const AstNode *node)
     case astGenericParam:
         CLONE_MANY(genericParam, constraints);
         break;
+    case astTupleXform:
+        CLONE_ONE(xForm, target);
+        CLONE_MANY(xForm, args);
+        CLONE_ONE(xForm, cond);
+        CLONE_ONE(xForm, xForm);
     case astGenericDecl:
         CLONE_MANY(genericDecl, params);
         CLONE_ONE(genericDecl, decl);

--- a/src/cxy/lang/frontend/ast.h
+++ b/src/cxy/lang/frontend/ast.h
@@ -131,6 +131,7 @@ struct StrPool;
     f(AsmOperand)           \
     f(NodeArray)            \
     f(Exception)            \
+    f(TupleXform)           \
     CXY_LANG_AST_EXP_TAGS(f)    \
     CXY_LANG_AST_STMT_TAGS(f)   \
     CXY_LANG_AST_DECL_TAGS(f)   \
@@ -337,6 +338,20 @@ struct AstNode {
             AstNode *params;
             AstNode *body;
         } exception;
+
+        struct {
+            AstNode *target;
+            AstNode *args;
+            AstNode *cond;
+            AstNode *xForm;
+        } xForm;
+
+        struct {
+            AstNode *tuple;
+            AstNode *args;
+            AstNode *cond;
+            AstNode *xform;
+        } xFormExpr;
 
         struct {
             cstring value;

--- a/src/cxy/lang/frontend/lexer.c
+++ b/src/cxy/lang/frontend/lexer.c
@@ -403,6 +403,8 @@ Token advanceLexer(Lexer *lexer)
                 return makeToken(lexer, &begin, tokLAnd);
             if (acceptChar(lexer, '='))
                 return makeToken(lexer, &begin, tokBAndEqual);
+            if (acceptChar(lexer, '.'))
+                return makeToken(lexer, &begin, tokBAndDot);
             return makeToken(lexer, &begin, tokBAnd);
         }
 

--- a/src/cxy/lang/frontend/operator.h
+++ b/src/cxy/lang/frontend/operator.h
@@ -91,7 +91,8 @@ extern "C" {
     f(DestructorOverload,       "destructor", "destructor")    \
     f(HashOverload,             "hash",       "hash")          \
     f(DestructorFwd,            "destructor_fwd",  "destructor__fwd") \
-    f(InitDefaults,             "init_defaults", "init_defaults")
+    f(InitDefaults,             "init_defaults", "init_defaults")\
+    f(Redirect,                 "redirect", "&.")
 
 typedef enum {
     opInvalid,

--- a/src/cxy/lang/frontend/strings.h
+++ b/src/cxy/lang/frontend/strings.h
@@ -121,6 +121,8 @@ extern "C" {
     f(resolve)                  \
     f(reject)                   \
     f(result)                   \
+    f(clib)                     \
+    f(src)                      \
     ff(__LLVM_global_ctors, "llvm.global_ctors") \
     ff(ctor_section,        ".ctor")             \
     ff(sptr_ref,            "__smart_ptr_get")   \

--- a/src/cxy/lang/frontend/token.h
+++ b/src/cxy/lang/frontend/token.h
@@ -60,6 +60,7 @@ extern "C" {
     f(DivEqual, "/=")               \
     f(ModEqual, "%=")               \
     f(BAndEqual, "&=")              \
+    f(BAndDot,   "&.")              \
     f(BXorEqual, "^=")              \
     f(BOrEqual, "|=")               \
     f(Quote,    "`")                \

--- a/src/cxy/lang/frontend/types.c
+++ b/src/cxy/lang/frontend/types.c
@@ -286,9 +286,9 @@ bool isTypeAssignableFrom(const Type *to, const Type *from)
         return typeIs(from, Pointer) && typeIs(from->pointer.pointed, Null);
     case typClass:
         if (typeIs(from, This))
-            return to == from->_this.that;
+            return isTypeAssignableFrom(to, from->_this.that);
         if (typeIs(from, Class) && from->tClass.inheritance->base)
-            return to == from->tClass.inheritance->base;
+            return isTypeAssignableFrom(to, from->tClass.inheritance->base);
         if (typeIs(from, Class) && getTypeDecl(to) == getTypeDecl(from))
             // TODO workaround circular types
             return true;
@@ -1282,7 +1282,9 @@ bool isDestructible(const Type *type)
     }
 
     return isTupleType(type) &&
-           hasFlags(type, flgReferenceMembers | flgImplementsDeinit);
+           hasFlags(type,
+                    flgReferenceMembers | flgImplementsDeinit |
+                        flgFuncTypeParam);
 }
 
 void pushThisReference(const Type *this, AstNode *node)

--- a/src/cxy/lang/frontend/types.h
+++ b/src/cxy/lang/frontend/types.h
@@ -152,7 +152,7 @@ struct MirType;
             bool generated;                                                    \
         };                                                                     \
     };                                                                         \
-    const struct MirType *mir;
+    const Type *retyped;
 
 #ifdef __cpluplus
 

--- a/src/cxy/lang/frontend/visitor.c
+++ b/src/cxy/lang/frontend/visitor.c
@@ -53,6 +53,11 @@
     case astException:                                                         \
         MODE##VisitManyNodes(visitor, node->exception.params);                 \
         break;                                                                 \
+    case astTupleXform:                                                        \
+        MODE##Visit(visitor, node->xForm.target);                              \
+        MODE##Visit(visitor, node->xForm.cond);                                \
+        MODE##Visit(visitor, node->xForm.xForm);                               \
+        break;                                                                 \
     case astProgram:                                                           \
         MODE##VisitManyNodes(visitor, node->program.top);                      \
         MODE##VisitManyNodes(visitor, node->program.decls);                    \

--- a/src/cxy/lang/middle/eval/comptime.c
+++ b/src/cxy/lang/middle/eval/comptime.c
@@ -99,6 +99,7 @@ static AstNode *getName(EvalContext *ctx,
     case astEnumOptionDecl:
     case astAttr:
     case astAnnotation:
+    case astTypeDecl:
         name = node->_name;
         break;
     case astPrimitiveType:

--- a/src/cxy/lang/middle/eval/eval.c
+++ b/src/cxy/lang/middle/eval/eval.c
@@ -368,6 +368,7 @@ void initEvalVisitor(AstVisitor *visitor, EvalContext *ctx)
         [astTupleType] = evalTypeDecl,
         [astArrayType] = evalTypeDecl,
         [astRef] = evalRef,
+        [astTupleXform] = evalXformType,
         [astIdentifier] = astVisitSkip,
         [astTypeRef] = astVisitSkip,
         [astList] = astVisitSkip,

--- a/src/cxy/lang/middle/eval/eval.h
+++ b/src/cxy/lang/middle/eval/eval.h
@@ -62,6 +62,7 @@ void evalPathEpilogue(AstVisitor *visitor,
 
 void evalIfStmt(AstVisitor *visitor, AstNode *node);
 void evalForStmt(AstVisitor *visitor, AstNode *node);
+void evalXformType(AstVisitor *visitor, AstNode *node);
 bool isNoopNodeAfterEval(const AstNode *node);
 
 #ifdef __cplusplus

--- a/src/cxy/lang/middle/eval/xform.c
+++ b/src/cxy/lang/middle/eval/xform.c
@@ -1,0 +1,84 @@
+//
+// Created by Carter Mbotho on 2025-03-12.
+//
+
+#include "eval.h"
+
+#include "lang/frontend/flag.h"
+#include "lang/frontend/ttable.h"
+
+#include <core/alloc.h>
+
+void evalXformType(AstVisitor *visitor, AstNode *node)
+{
+    EvalContext *ctx = getAstVisitorContext(visitor);
+    if (!evaluate(visitor, node->xForm.target)) {
+        node->tag = astError;
+        return;
+    }
+    const Type *target = resolveUnThisUnwrapType(node->xForm.target->type);
+    if (!typeIs(target, Tuple)) {
+        logError(ctx->L,
+                 &node->xForm.target->loc,
+                 "unsupported type {t}, transforms only supported on tuple "
+                 "extressions",
+                 (FormatArg[]){{.t = target ?: makeErrorType(ctx->types)}});
+        node->tag = astError;
+        return;
+    }
+
+    const Type **members =
+        mallocOrDie(sizeof(const Type *) * target->tuple.count);
+    AstNode *arg1 = node->xForm.args, *arg2 = arg1->next;
+    int j = 0;
+    for (int i = 0; i < target->tuple.count; i++) {
+        const Type *member = target->tuple.members[i];
+        arg1->varDecl.init =
+            makeTypeReferenceNode(ctx->pool, member, &arg1->loc);
+        arg1->type = member;
+        if (arg2) {
+            arg2->varDecl.init =
+                makeIntegerLiteral(ctx->pool,
+                                   &arg2->loc,
+                                   i,
+                                   NULL,
+                                   getPrimitiveType(ctx->types, prtI64));
+            arg2->type = arg2->varDecl.init->type;
+        }
+        AstNode *cond = deepCloneAstNode(ctx->pool, node->xForm.cond);
+        if (cond) {
+            if (!evaluate(visitor, cond)) {
+                node->tag = astError;
+                free(members);
+                return;
+            }
+            if (!nodeIs(cond, BoolLit)) {
+                logError(ctx->L,
+                         &node->xForm.cond->loc,
+                         "comptime transform condition must evaluate to a "
+                         "boolean literal",
+                         NULL);
+                node->tag = astError;
+                free(members);
+                return;
+            }
+            if (!cond->boolLiteral.value)
+                continue;
+        }
+
+        AstNode *xForm = deepCloneAstNode(ctx->pool, node->xForm.xForm);
+        const Type *result = evalType(ctx, xForm);
+        if (typeIs(result, Error)) {
+            node->tag = astError;
+            free(members);
+            return;
+        }
+        members[j++] = xForm->type;
+    }
+
+    const Type *type = makeTupleType(ctx->types, members, j, flgNone);
+    free(members);
+    node->tag = astTypeRef;
+    node->type = type;
+    clearAstBody(node);
+}

--- a/src/cxy/lang/middle/mem/finalize.c
+++ b/src/cxy/lang/middle/mem/finalize.c
@@ -122,7 +122,7 @@ static void visitBackendCallExpr(AstVisitor *visitor, AstNode *node)
             func = findMemberDeclInType(type, S_CopyOverload);
         else if (isUnionType(type))
             func = type->tUnion.copyFunc->func.decl;
-        else if (isTupleType(type))
+        else if (isTupleType(type) && type->tuple.copyFunc)
             func = type->tuple.copyFunc->func.decl;
         break;
     case bfiDrop:
@@ -130,7 +130,7 @@ static void visitBackendCallExpr(AstVisitor *visitor, AstNode *node)
             func = findMemberDeclInType(type, S_DestructorOverload);
         else if (isUnionType(type))
             func = type->tUnion.destructorFunc->func.decl;
-        else if (isTupleType(type))
+        else if (isTupleType(type) && type->tuple.destructorFunc)
             func = type->tuple.destructorFunc->func.decl;
         var = resolveIdentifier(args);
         if (hasVariableDropFlags(var)) {

--- a/src/cxy/lang/middle/mem/manage.c
+++ b/src/cxy/lang/middle/mem/manage.c
@@ -544,6 +544,12 @@ static void visitTupleExpr(AstVisitor *visitor, AstNode *node)
     AstNode *expr = node->tupleExpr.elements;
     for (; expr; expr = expr->next) {
         astVisit(visitor, expr);
+        if (nodeIs(expr, CastExpr)) {
+            AstNode *to = expr->castExpr.to, *from = expr->castExpr.expr;
+            if (isVoidPointer(to->type) && hasFlag(from->type, Closure))
+                expr = from;
+        }
+
         if (isLeftValueExpr(expr) && nodeNeedsMemMgmt(expr))
             transformToCopyExpr(ctx, expr, deepCloneAstNode(ctx->pool, expr));
     }

--- a/src/cxy/lang/middle/sema/builtins.c
+++ b/src/cxy/lang/middle/sema/builtins.c
@@ -20,7 +20,7 @@ static AstNode *implementCallTupleCopy(TypingContext *ctx,
 {
     const Type *type = member->type;
     const Type *copy_ = type->tuple.copyFunc;
-    csAssert0(copy_);
+    csAssert0(copy_ || hasFlag(type, FuncTypeParam));
 
     return makeBackendCallExpr(
         ctx->pool,
@@ -34,7 +34,7 @@ static AstNode *implementCallTupleCopy(TypingContext *ctx,
                          member,
                          NULL,
                          type),
-        copy_->func.retType);
+        member->type);
 }
 
 static AstNode *implementCallStructCopyMember(TypingContext *ctx,
@@ -151,7 +151,7 @@ static AstNode *implementCallTupleDestructor(TypingContext *ctx,
 {
     const Type *type = member->type;
     const Type *destructor = type->tuple.destructorFunc;
-    csAssert0(destructor);
+    csAssert0(destructor || hasFlag(type, FuncTypeParam));
 
     return makeExprStmt(
         ctx->pool,
@@ -169,7 +169,7 @@ static AstNode *implementCallTupleDestructor(TypingContext *ctx,
                              member,
                              NULL,
                              type),
-            destructor->func.retType),
+            member->type),
         NULL,
         makeVoidType(ctx->types));
 }
@@ -709,7 +709,7 @@ void implementClassOrStructBuiltins(AstVisitor *visitor, AstNode *node)
 u64 removeClassOrStructBuiltins(AstNode *node, NamedTypeMember *nms)
 {
     AstNodeList members = {};
-    u64 count = 0, total = 0;
+    u64 count = hasFlag(node, Virtual), total = count;
     for (AstNode *it = node->structDecl.members; it;) {
         AstNode *member = it;
         it = it->next;

--- a/src/cxy/lang/middle/sema/call.c
+++ b/src/cxy/lang/middle/sema/call.c
@@ -186,7 +186,7 @@ void checkCallExpr(AstVisitor *visitor, AstNode *node)
             if (nodeIs(symbol, GenericParam))
                 symbol = getTypeDecl(rawType);
         }
-        else if (nodeIs(callee, TypeRef)) {
+        else if (nodeIs(callee, TypeRef) || nodeIs(callee, TypeDecl)) {
             symbol = getTypeDecl(rawType);
         }
 

--- a/src/cxy/lang/middle/sema/class.c
+++ b/src/cxy/lang/middle/sema/class.c
@@ -391,6 +391,7 @@ void checkClassDecl(AstVisitor *visitor, AstNode *node)
                                       implements,
                                       implementsCount,
                                       node->flags & flgTypeApplicable);
+        ((Type *)this->_this.that)->retyped = node->type;
         ((Type *)this)->_this.that = node->type;
     }
     else {

--- a/src/cxy/lang/middle/sema/function.c
+++ b/src/cxy/lang/middle/sema/function.c
@@ -270,7 +270,7 @@ void checkFunctionParam(AstVisitor *visitor, AstNode *node)
                           (const Type *[]){
                               makeVoidPointerType(ctx->types, flgNone), type_},
                           2,
-                          flgFuncTypeParam));
+                          flgFuncTypeParam | flgReferenceMembers));
         node->type = type->type;
         node->flags |= flgFuncTypeParam;
         return;

--- a/src/cxy/lang/middle/sema/generics.c
+++ b/src/cxy/lang/middle/sema/generics.c
@@ -110,7 +110,7 @@ static const Type *closureArgToClosureParamType(TypingContext *ctx,
                       (const Type *[]){makeVoidPointerType(ctx->types, flgNone),
                                        funcTypeDecl->type},
                       2,
-                      flgFuncTypeParam);
+                      flgFuncTypeParam | flgReferenceMembers);
     free(funcTypeParams);
     return paramType;
 }

--- a/src/cxy/lang/middle/sema/node.c
+++ b/src/cxy/lang/middle/sema/node.c
@@ -446,8 +446,14 @@ bool transformToTruthyOperator(AstVisitor *visitor, AstNode *node)
     if (!isClassOrStructType(type))
         return false;
 
-    const Type *member = findMemberInType(type, S_Truthy);
-    if (member == NULL)
+    do {
+        const Type *member = findMemberInType(type, S_Truthy);
+        if (member != NULL)
+            break;
+        type = getTypeBase(type);
+    } while (type);
+
+    if (type == NULL)
         return false;
 
     transformToMemberCallExpr(

--- a/src/cxy/lang/middle/sema/unary.c
+++ b/src/cxy/lang/middle/sema/unary.c
@@ -130,8 +130,8 @@ static const Type *checkPrefixExpr(AstVisitor *visitor,
             else {
                 logError(ctx->L,
                          &node->unaryExpr.operand->loc,
-                         "struct '{t}' does not truthy dereference "
-                         "`deref` operator",
+                         "struct '{t}' does not define a truthy "
+                         "`!!` operator",
                          (FormatArg[]){{.t = operand}});
                 operand = ERROR_TYPE(ctx);
             }

--- a/src/cxy/runtime/builtins.cxy
+++ b/src/cxy/runtime/builtins.cxy
@@ -89,22 +89,22 @@ pub func __bswap16(x: u16) => <u16>(((x >> 8) & 0xff) | ((x & 0xff) << 8))
 
 @inline
 pub func __bswap32(x: u32) => (
-      ((x & 0xff000000:u32) >> 24)
-    | ((x & 0x00ff0000:u32) >> 8)
-    | ((x & 0x0000ff00:u32) << 8)
-    | ((x & 0x000000ff:u32) << 24)
+      ((x & 0xff000000 as u32) >> 24)
+    | ((x & 0x00ff0000 as u32) >> 8)
+    | ((x & 0x0000ff00 as u32) << 8)
+    | ((x & 0x000000ff as u32) << 24)
 )
 
 @inline
 pub func __bswap64(x: u64) => (
-      ((x & 0xff00000000000000:u64) >> 56)
-    | ((x & 0x00ff000000000000:u64) >> 40)
-    | ((x & 0x0000ff0000000000:u64) >> 24)
-    | ((x & 0x000000ff00000000:u64) >> 8)
-    | ((x & 0x00000000ff000000:u64) << 8)
-    | ((x & 0x0000000000ff0000:u64) << 24)
-    | ((x & 0x000000000000ff00:u64) << 40)
-    | ((x & 0x00000000000000ff:u64) << 56)
+      ((x & 0xff00000000000000 as u64) >> 56)
+    | ((x & 0x00ff000000000000 as u64) >> 40)
+    | ((x & 0x0000ff0000000000 as u64) >> 24)
+    | ((x & 0x000000ff00000000 as u64) >> 8)
+    | ((x & 0x00000000ff000000 as u64) << 8)
+    | ((x & 0x0000000000ff0000 as u64) << 24)
+    | ((x & 0x000000000000ff00 as u64) << 40)
+    | ((x & 0x00000000000000ff as u64) << 56)
 )
 
 type sptr = ^void
@@ -116,7 +116,7 @@ struct __mem {
     dctor: func(ptr: sptr) -> void
 }
 
-#const MEMORY_MAGIC = 0xAEAEAEAE:u32
+#const MEMORY_MAGIC = 0xAEAEAEAE as u32
 
 @[pure, linkage("External"), noinline, optimize(0), __override_builtin("__smart_ptr_alloc")]
 func __smart_ptr_alloc(size: u64, dctor: func(ptr: sptr) -> void = null) {
@@ -235,11 +235,13 @@ pub struct Optional[T] {
 
     @inline func `!!`() => ok
     @inline func `deref`() { return val }
+    @inline func `&.`() { return &val }
     @optimize(0) func move() { ok = false; return &&val }
     // Short circuit to !!opt ? opt.move() : def
     @inline func `||`(def: T) => ok? move() : &&def
     @inline const func `!!`() => ok
     @inline const func `deref`() { return val }
+    @inline const func `&.`() { return &val }
 }
 
 /* Creates a valid optional value */
@@ -251,7 +253,7 @@ pub func Some[T](value: T) => Optional[T]{ ok: true, val: &&value }
 pub func None[T]() => Optional[T]()
 
 pub type HashCode = u32
-#const FNV_32_PRIME = 0x01000193:u32
+#const FNV_32_PRIME = 0x01000193 as u32
 
 @inline
 pub func hash_fnv1a_uint8(h: HashCode, x: u8) : HashCode
@@ -274,7 +276,7 @@ pub func hash_fnv1a_ptr(h: HashCode, ptr: ^const void) =>
 pub func hash_fnv1a_string(h: HashCode, str: string)
 {
     var i = 0;
-    while (str.[i] != '\0':char) {
+    while (str.[i] != '\0' as char) {
         h = hash_fnv1a_uint8(h, <u8>str.[i]);
         i++
     }
@@ -305,7 +307,7 @@ pub func hash_fnv1a_string_n_igc(h: HashCode, str: ^const char, len: u64)
 pub func hash_fnv1a_string_igc(h: HashCode, str: const string)
 {
     var i = 0;
-    while (str.[i] != '\0':char) {
+    while (str.[i] != '\0' as char) {
         var c = toupper(<i32>str.[i]);
         h = hash_fnv1a_uint8(h, <u8>c);
         i++
@@ -398,7 +400,7 @@ pub struct __string {
     }
 
     const func trimLeft() {
-        var i = 0:u64
+        var i = 0 as u64
         while (i < _size && isSpace!(s.[i]))
             i++
         if (i != 0) {
@@ -447,7 +449,7 @@ pub struct __string {
     @inline const func str() => s
     @inline const func empty() => _size == 0
     @inline const func isnt() {
-        return !empty() && s.[_size] == '\0':char
+        return !empty() && s.[_size] == '\0' as char
     }
 
     const func substr(start: u64, count: i64 = -1) {
@@ -463,7 +465,7 @@ pub struct __string {
     const func copyto(buf: ^char, size: u64) {
         assert!(size > _size)
         memcpy(buf !: ^void, s !: ^void, _size)
-        buf.[_size] = '\0':char
+        buf.[_size] = '\0' as char
     }
 
     const func toi[T](base: i32 = 0) {
@@ -479,7 +481,7 @@ pub struct __string {
     }
 
     func indexOf(ch: char) : Optional[u64] {
-        var i = 0:u64;
+        var i = 0 as u64;
         while (i < _size) {
             if (s.[i] == ch)
                 return Some(i)
@@ -510,14 +512,14 @@ pub struct __string {
     const func startswith(suffix: This) {
         if (suffix.size() > size())
             return false;
-        return substr(0:u64, <i64>suffix.size()) == suffix
+        return substr(0 as u64, <i64>suffix.size()) == suffix
     }
 
     const func find(part: This) : Optional[u64] {
         if (part.empty())
             return empty()? None[u64]() : Some(_size - 1);
         var i = _size;
-        var j = 0:u64;
+        var j = 0 as u64;
         var p = s !: ^const char;
         while (i >= part._size) {
             i--
@@ -545,7 +547,7 @@ pub struct __string {
     }
 }
 
-#const CXY_STRING_BUILDER_DEFAULT_CAPACITY = 32:u64
+#const CXY_STRING_BUILDER_DEFAULT_CAPACITY = 32 as u64
 
 @[inline, pure]
 pub func isnull[T](cls: &const T) {
@@ -620,9 +622,9 @@ pub class OutputStream {
     @inline
     func appendBool(val: bool) {
         if (val)
-            append("true" !: ^const void, 4:u64)
+            append("true" !: ^const void, 4 as u64)
         else
-            append("false" !: ^const void, 5:u64)
+            append("false" !: ^const void, 5 as u64)
     }
 
     func appendPointer[T](ptr: &const T) {
@@ -759,7 +761,7 @@ pub class String : OutputStream {
     - _data: ^char = null;
 
     - func grow(growSize: u64) {
-        const newSize = max(_size + growSize, 16:u64);
+        const newSize = max(_size + growSize, 16 as u64);
         if (this._data == null) {
             this._data = <^char> malloc(newSize + 1)
             this._capacity = newSize
@@ -811,7 +813,7 @@ pub class String : OutputStream {
     func resize(newSize: u64) {
         assert!(_capacity <= newSize)
         _size = newSize
-        _data.[_size] = '\0':char
+        _data.[_size] = '\0' as char
     }
 
     func clear() : void {
@@ -835,7 +837,7 @@ pub class String : OutputStream {
     }
 
     func trimLeft() {
-        var i = 0:u64
+        var i = 0 as u64
         while (i < _size && isSpace!(_data.[i]))
             i++
         if (i != 0) {
@@ -862,7 +864,7 @@ pub class String : OutputStream {
     }
 
     const func indexOf(ch: char) : Optional[u64] {
-        var i = 0:u64;
+        var i = 0 as u64;
         while (i < _size) {
             if (_data.[i] == ch)
                 return Some(i)
@@ -965,7 +967,7 @@ pub class String : OutputStream {
     }
 
     const func `..`() {
-        var i:i32 = 0;
+        var i = 0 as i32;
         return () : Optional[(char, i32)] => {
             if (i < _size)
                 return Some((_data.[i], i++))
@@ -1010,7 +1012,7 @@ pub class BufferedOutputStream: OutputStream {
     }
 
     func append(data: ^const void, size: u64): Optional[u64] {
-        var room = _capacity - _size;
+        var room = _capacity - _size
         if (size > room && _size > 0) {
             sync()
             room = _capacity
@@ -1144,7 +1146,7 @@ func __union_dctor[T](obj: &T) {
                 #const M = typeat!(T, i);
                 #if (M.isClass || M.isDestructible)
                     __forcedrop!(y)
-                else #if (has_member!(#M, "op__destructor", #func() -> void))
+                else #if (!M.isReference && has_member!(#M, "op__destructor", #func() -> void))
                     y.op__destructor()
             }
         }
@@ -1334,8 +1336,8 @@ struct CallTrace {
 
 struct StackTrace {
     - calls: ^CallTrace = null;
-    - size = 0:u64;
-    - capacity = 0:u64;
+    - size = 0 as u64;
+    - capacity = 0 as u64;
 
     - func grow() {
         if (size >= capacity) {
@@ -1439,43 +1441,6 @@ pub func panicUnhandledException(ex: Exception) {
     abort()
 }
 
-pub struct Lambda[Fun] {
-    require!(Fun.isFunction, "type '{t}' must be a func type param", Fun)
-    lambda: lambda_of!(Fun)
-
-    func `init`(fun: Fun) {
-        this.lambda = fun
-    }
-
-    func `()`(...params: auto) {
-        #if (Fun.hasVoidReturnType)
-            lambda(...&&params)
-        else
-            return lambda(...&&params)
-    }
-
-    func `destructor`() {
-        if (lambda.0) {
-            #if (defined __DEBUG && defined TRACE_MEMORY)
-                __smart_ptr_drop_trace(lambda.0, file!, line!)
-            else
-                __smart_ptr_drop(lambda.0)
-            lambda.0 = null
-        }
-    }
-
-    func `copy`() {
-        if (lambda.0) {
-            #if (defined __DEBUG && defined TRACE_MEMORY)
-                __smart_ptr_get_trace(lambda.0, file!, line!)
-            else
-                __smart_ptr_get(lambda.0)
-            return This{lambda: lambda}
-        }
-        return This{lambda: lambda}
-    }
-}
-
 pub class MemoryOutputStream : OutputStream {
     - _buffer: ^void
     - _capacity: u64
@@ -1507,8 +1472,8 @@ pub class MemoryOutputStream : OutputStream {
 }
 
 struct Style {
-    color = 0:i8;
-    - _bg = 0:i8;
+    color = 0 as i8;
+    - _bg = 0 as i8;
     - _bold = false;
     - _italics = false;
     - _underline = false;
@@ -1540,23 +1505,23 @@ struct Style {
     const func `()`(cfg: string, bg: This) {
         var x = *this;
         const p = cfg !: ^const char;
-        var i = 0:i32;
-        while (p.[i] != '\0':char) {
+        var i = 0 as i32;
+        while (p.[i] != '\0' as char) {
             var on = true;
-            if (p.[i] == '~':char) {
+            if (p.[i] == '~' as char) {
                 i++
                 on = false
             }
 
             switch(p.[i++]) {
-                case 'b':char => x._bold = on
-                case 'i':char => x._italics = on
-                case 'u':char => x._underline = on
-                case 'f':char => x._faded = on
-                case 'p':char => x._blink = on
+                case 'b' as char => x._bold = on
+                case 'i' as char => x._italics = on
+                case 'u' as char => x._underline = on
+                case 'f' as char => x._faded = on
+                case 'p' as char => x._blink = on
                 default => assert!(false)
             }
-            assert!(p.[i] == '\0':char || p.[i++] == '|':char)
+            assert!(p.[i] == '\0' as char || p.[i++] == '|' as char)
         }
         if (bg.color >= 0)
             x._bg = bg.color
@@ -1596,7 +1561,7 @@ macro ok(cond) {
     func runTest(testCase: (string, func() -> !void)) {
         testCase.1() catch {
             // test case failed
-            stdout << "\r  " << Repeat(' ':char, 100)
+            stdout << "\r  " << Repeat(' ' as char, 100)
                    << "\r  " << RED("b") << "\xE2\x9C\x98 " << WHT << testCase.0
                    << DEF << " "
             ex!.header( &stdout )
@@ -1606,7 +1571,7 @@ macro ok(cond) {
             return false
         }
 
-        stdout << "\r  " << Repeat(' ':char, 100)
+        stdout << "\r  " << Repeat(' ' as char, 100)
                << "\r  " << GRN("b") << "\xE2\x9C\x93 " << WHT << testCase.0
                << DEF << "\n"
         return true

--- a/src/cxy/runtime/builtins.test.cxy
+++ b/src/cxy/runtime/builtins.test.cxy
@@ -1,7 +1,7 @@
 test "__bswap" {
-    ok!(__bswap64(0xff00000000000000:u64) == 0x00000000000000ff:u64)
-    ok!(__bswap32(0xff000000:u32) == 0x000000ff:u32)
-    ok!(__bswap16(0xff00:u16) == 0x00ff:u16)
+    ok!(__bswap64(0xff00000000000000 as u64) == 0x00000000000000ff as u64)
+    ok!(__bswap32(0xff000000 as u32) == 0x000000ff as u32)
+    ok!(__bswap16(0xff00 as u16) == 0x00ff as u16)
 }
 
 test "min/max" {
@@ -16,14 +16,14 @@ test "min/max" {
 
 test "String::(indexOf/rIndexOf)" {
     var s = String("Hello World");
-    var idx = s.indexOf('C':char);
+    var idx = s.indexOf('C' as char);
     ok!(!idx)
 
-    idx = s.indexOf('o':char);
+    idx = s.indexOf('o' as char);
     ok!(!!idx)
     ok!(*idx == 4)
 
-    idx = s.rIndexOf('o':char);
+    idx = s.rIndexOf('o' as char);
     ok!(!!idx)
     ok!(*idx == 7)
 }

--- a/src/cxy/stdlib/args.cxy
+++ b/src/cxy/stdlib/args.cxy
@@ -3,7 +3,7 @@ module args
 import { Vector } from "stdlib/vector.cxy"
 import { HashMap } from "stdlib/hash.cxy"
 
-macro NOSF '\0':char
+macro NOSF  '\0'as char
 
 exception ParserError(msg: String) => msg != null? msg.str() : ""
 
@@ -71,7 +71,7 @@ struct ParamContainer {
 pub class Command {
     name: __string
     desc: __string
-    longestParam = 0:u64;
+    longestParam = 0 as u64;
     interactive = false;
     hasLocalFlags = false;
     params = ParamContainer{};
@@ -91,12 +91,12 @@ pub class Command {
         while (i < args.size()) {
             var full = args.[i++];
             var arg = __string(full);
-            if (arg.[0] != '-':char) {
+            if (arg.[0] != '-' as char) {
                 positionals.push(arg)
                 continue
             }
             var val = __string();
-            var idx = arg.indexOf('=':char);
+            var idx = arg.indexOf('=' as char);
             if (idx) {
                 var index = *idx;
                 val = arg.substr(index + 1)
@@ -104,7 +104,7 @@ pub class Command {
             }
 
             var paramOpt = None[&Param]();
-            if (arg.[1] == '-':char) {
+            if (arg.[1] == '-' as char) {
                 // skip the --
                 arg = arg.substr(2)
                 if (arg.empty()) {
@@ -135,7 +135,7 @@ pub class Command {
                     raise ParserError(f"value given to an option argument '${name}'")
             }
             else if (val.empty()) {
-                if (i >= args.size() || args.[i].[0] == '-':char)
+                if (i >= args.size() || args.[i].[0] == '-' as char)
                     raise ParserError(f"argument '${arg}' is missing a value")
                 val = __string(args.[i++])
             }
@@ -276,8 +276,8 @@ pub class App {
     version: __string
     desc: __string
     defaultCmd: __string
-    longestParam = 0:u64;
-    longestCmd = 0:u64;
+    longestParam = 0 as u64;
+    longestCmd = 0 as u64;
     params = ParamContainer{};
     commands = HashMap[__string, Command]();
 
@@ -366,7 +366,7 @@ pub class App {
 
     func parse(args: [string]): i32 {
         var name = defaultCmd;
-        if (args.size() > 1 && args.[1].[0] != '-':char ) {
+        if (args.size() > 1 && args.[1].[0] != '-' as char ) {
            name = __string(args.[1])
            args = args.view(2)
         }

--- a/src/cxy/stdlib/base64.cxy
+++ b/src/cxy/stdlib/base64.cxy
@@ -3,7 +3,7 @@ module base64
 const b64table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 const ASCII_LOOKUP: [u8, 256] = [
     /* ASCII table */
-    64:u8,
+    64 as u8,
         64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
@@ -24,7 +24,7 @@ const ASCII_LOOKUP: [u8, 256] = [
 
 pub func encodeBuffer(os: &OutputStream, data: ^const void, size: u64) {
     var p = data !: ^const u8
-    var i = 0:u64;
+    var i = 0 as u64;
     while (size >= 3) {
         // |X|X|X|X|X|X|-|-|
         os.append(ptrof b64table.[((p.[i] & 0xFC) >> 2)], 1)
@@ -83,7 +83,7 @@ pub exception Base64Error(msg: string) => msg
 
 pub func decodeBuffer(os: &OutputStream, data: ^const void, size: u64): !void {
     var sz = size
-    var i = 0:u64;
+    var i = 0 as u64;
     const p = data !: ^const u8;
 
     while (sz > 4) {
@@ -138,6 +138,113 @@ pub func decode[T](os: &OutputStream, value: &const T) : !void {
         else {
             if (value != null)
                 decodeBuffer(os, value !: ^const void, len!(value))
+        }
+    }
+    else {
+        error!("Type {t} is currently unsupported", #T)
+    }
+}
+
+const b64tableU = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+pub func urlEncodeBuffer(os: &OutputStream, buf: ^const void, size: u64) {
+    var i = 0 as u64;
+    var p = buf !: ^const u8;
+    while (i < (<i64>size)-2) {
+        os << <char>(b64tableU.[(p.[i] >> 2) & 0x3F] )
+        os << <char>(b64tableU.[((p.[i] & 0x3) << 4) | (p.[i + 1] & 0xF0) >> 4] )
+        os << <char>(b64tableU.[((p.[i + 1] & 0xF) << 2) | (p.[i + 2] & 0xC0) >> 6] )
+        os << <char>(b64tableU.[p.[i + 2] & 0x3F] )
+        i +=2
+    }
+
+    if (i < size) {
+        os << <char>(b64tableU.[(p.[i] >> 2) & 0x3F])
+        if (i == (size - 1)) {
+            os << <char>(b64tableU.[((p.[i] & 0x3) << 4)])
+        } else {
+            os << <char>(b64tableU.[((p.[i] & 0x3) << 4) | (p.[i + 1] & 0xF0) >> 4])
+            os << <char>(b64tableU.[((p.[i + 1] & 0xF) << 2)])
+        }
+    }
+}
+
+pub func urlEncodeSize(size: u64) {
+    var i = size - (size % 2)
+    var len = 0 as u64
+    if (i > 0) {
+        len = i*2
+    }
+    if (i < size) {
+        len++
+        if (i == (size - 1))
+            len++
+        else
+            len += 2
+    }
+    return len
+}
+
+pub func urlDecodeBuffer(os: &OutputStream, buf: ^const void, size: u64): !void {
+    var p = buf !: const ^u8
+    var i = 0 as u64
+    var sz = size
+    while (sz > 4) {
+        var it = ptroff!(p + i)
+        if (ASCII_LOOKUP.[it.[0]] == 64 ||
+            ASCII_LOOKUP.[it.[1]] == 64 ||
+            ASCII_LOOKUP.[it.[2]] == 64 ||
+            ASCII_LOOKUP.[it.[3]] == 64)
+        {
+            raise Base64Error("Base64::urlDecode - invalid base64 encoded string passed");
+        }
+
+        os << <char>(<u8>(ASCII_LOOKUP.[it.[0]] << 2 | ASCII_LOOKUP.[it.[1]] >> 4))
+        os << <char>(<u8>(ASCII_LOOKUP.[it.[1]] << 4 | ASCII_LOOKUP.[it.[2]] >> 2))
+        os << <char>(<u8>(ASCII_LOOKUP.[it.[2]] << 6 | ASCII_LOOKUP.[it.[3]]))
+        sz -= 4;
+        i += 4
+    }
+
+    var it = ptroff!(p + i)
+    if (sz > 1) {
+       os << <char>(ASCII_LOOKUP.[it.[0]] << 2 | ASCII_LOOKUP.[it.[1]] >> 4)
+    }
+    if (sz > 2) {
+       os << <char>(ASCII_LOOKUP.[it.[1]] << 4 | ASCII_LOOKUP.[it.[2]] >> 2)
+    }
+    if (sz > 3) {
+       os << <char>(ASCII_LOOKUP.[it.[2]] << 6 | ASCII_LOOKUP.[it.[3]]);
+    }
+}
+
+pub func urlEncode[T](os: &OutputStream, value: &const T) {
+    require!(T.isString, "Type {t} must a string, use urlEncodeBuffer instead", #T)
+    #if (T.isStruct) {
+        urlEncodeBuffer(os, value.data(), value.size())
+    }
+    else #if (T.isClass) {
+        if (value != null)
+            urlEncodeBuffer(os, value.data(), value.size())
+    }
+    else {
+        if (value != null)
+            urlEncodeBuffer(os, value !: ^const void, len!(value))
+    }
+}
+
+pub func urlDecode[T](os: &OutputStream, value: &const T) : !void {
+    #if (T.isString) {
+        #if (T.isStruct) {
+            urlDecodeBuffer(os, value.data() !: ^const void, value.size())
+        }
+        else #if (T.isClass) {
+            if (value != null)
+                urlDecodeBuffer(os, value.data() !: ^const void, value.size())
+        }
+        else {
+            if (value != null)
+                urlDecodeBuffer(os, value !: ^const void, len!(value))
         }
     }
     else {

--- a/src/cxy/stdlib/build.cxy
+++ b/src/cxy/stdlib/build.cxy
@@ -99,11 +99,11 @@ pub class Builder {
     - func parseOptions(args: [string]) {
         for (const i: 0..args.size()) {
             const arg = __string(args.[i])
-            if (arg.[0] != '-':char || arg.[1] != 'D':char)
+            if (arg.[0] != '-' as char || arg.[1] != 'D' as char)
                 continue
             var name = arg
             var value = __string();
-            const idx = arg.indexOf('=':char)
+            const idx = arg.indexOf('=' as char)
             if (idx)
                 raise BuildError(f"invalid build option '${arg}', expect -DOPTION=VALUE")
             var name = arg.substr(0, *idx)

--- a/src/cxy/stdlib/coro.cxy
+++ b/src/cxy/stdlib/coro.cxy
@@ -7,7 +7,7 @@ import "native/evloop/ae.h" as ae
 
 import { List } from "./list.cxy"
 
-import "./native/index.cxy"
+@__cc "native/evloop/ae.c"
 
 type Context = ^jmp.sigjmp_buf
 type Stack = ^void
@@ -106,7 +106,7 @@ func stackAlign(size: u64, align: u64) =>
 
 #if (! defined CORO_STACK_SIZE) {
     // 256kb stack by default
-    macro CORO_STACK_SIZE() 1024:u64 * 1024:u64
+    macro CORO_STACK_SIZE() 1024 as u64 * 1024 as u64
 }
 
 var stackSize = stackAlign(CORO_STACK_SIZE!, SysConfPageSize);
@@ -115,7 +115,7 @@ struct CachedStack {
     link: ^This
 }
 
-macro MAX_CACHED_STACKS 32:u64
+macro MAX_CACHED_STACKS 32 as u64
 
 class CoroutineScheduler {
     running: ^Coroutine = null; /* Currently running coroutine. */

--- a/src/cxy/stdlib/fetch.cxy
+++ b/src/cxy/stdlib/fetch.cxy
@@ -1,0 +1,692 @@
+module fetch
+
+import { Address, Socket, BufferedSocketOutputStream, getRemoteAddress } from "./net.cxy"
+import { TcpSocket, tcpConnect } from "./tcp.cxy"
+import { SslSocket } from "./ssl.cxy"
+import { Path, getFileSize } from "./path.cxy"
+import { Vector } from "./vector.cxy"
+import { HashMap } from "./hash.cxy"
+import { Time } from "./time.cxy"
+import { HeaderMap, Method, SendFile, Status, HttpError, methodFromString } from "./http.cxy"
+
+import "./log.cxy"
+import "./os.cxy" as os
+import "./base64.cxy" as base64
+
+import "native/http/llhttp.h" as parser
+
+macro CRLF =    "\r\n"
+
+enum Encoding {
+    UrlEncode, MultipartForm, MultipartOther
+}
+
+func urlEncode(os: &OutputStream, url: __string) {
+    const hex = "0123456789abcdef"
+    var p = url.data() !: ^const u8;
+    for (var i: 0..url.size()) {
+        if (   ('a' as char <= url.[i] && url.[i] <= 'z' as char)
+            || ('A' as char <= url.[i] && url.[i] <= 'Z' as char)
+            || ('0' as char <= url.[i] && url.[i] <= '9' as char)
+           )
+        {
+            os << url.[i];
+        }
+        else {
+            os << '%' as char
+            os << hex.[p.[i] >> 4]
+            os << hex.[p.[i] & 0xF];
+        }
+    }
+}
+
+const LOG_TAG = "HTTP_CLIENT";
+
+struct FileUpload {
+    _name: String;
+    _contentType: __string;
+    _path: Path = null
+
+    func `init`(name: String, path: Path, contentType: __string = "".s) {
+        _name = &&name
+        _path = &&path
+        _contentType = &&contentType
+    }
+
+    @inline
+    const func contentType() => _contentType
+
+    @inline
+    const func path() => &_path
+
+    @inline
+    const func name() => &_name
+
+    @inline
+    const func open(): !os.FileDescriptor {
+        return os.open(_path.__str())
+    }
+
+    @inline
+    const func size(): !u64 => getFileSize(_path.str())
+
+    @inline
+    const func `==`(other: &const This) => _name == other._name
+}
+
+const CONTENT_DISPOSITION = "Content-Disposition: form-data; name=\"".s;
+const CONTENT_DISPOSITION_FILENAME = "\"; filename=\"".s;
+const CONTENT_TYPE = "Content-Type: ".s;
+
+pub class Form {
+    - _encoding = Encoding.UrlEncode;
+    - _boundary: String = null;
+    - _data = HeaderMap();
+    - _uploads = Vector[FileUpload]();
+
+    func `init`(boundary: String) {
+        this._boundary = boundary
+    }
+
+    @inline
+    func add(name: String, value: String) {
+        _data.[&&name] = &&value
+    }
+
+    @inline
+    func upload(name: String, path: Path, contentType: __string = "".s) {
+        _uploads.push(FileUpload(&&name, &&path, contentType))
+        _encoding = .MultipartForm
+    }
+
+    @inline
+    const func `!!`() => !_data.empty() || !_uploads.empty();
+
+    - const func urlEncode(os: &OutputStream) {
+        var first = true
+        for (const item: _data) {
+            if (!first)
+                os << "&"
+            base64.urlEncode(os, &item.0)
+            os << "="
+            base64.urlEncode(os, &item.1)
+            first = false
+        }
+    }
+
+    - const func multipartEncode(os: &BufferedSocketOutputStream): !void {
+        for (const item: _data) {
+            os << "--" << _boundary << CRLF!
+               << CONTENT_DISPOSITION
+               << item.0 << '"' << CRLF!
+               << CRLF! << item.1 << CRLF!
+        }
+
+        if (_uploads.empty()) {
+            os << "--" << _boundary << "--"
+            return
+        }
+
+        for (const item, _: _uploads) {
+            os << "--" << _boundary << CRLF!
+               << CONTENT_DISPOSITION
+               << item.name() << CONTENT_DISPOSITION_FILENAME << item.path().name()
+               << "\"" << CRLF!
+
+            if (!item.contentType().empty())
+                os << CONTENT_TYPE << item.contentType() << CRLF!
+            os << CRLF!
+
+            var fd = item.open()
+            var sent =  os.sendFile(fd.fd, 0, fd.size())
+            if (!sent)
+                raise HttpError(f"uploading file '${item.path()}' failed: ${strerr()}")
+            os << CRLF!
+        }
+
+        os << "--" << _boundary << "--"
+    }
+
+    const func encode(os: &BufferedSocketOutputStream): !void {
+        if (_data.empty() && _uploads.empty())
+            return
+        if (_encoding == .UrlEncode)
+            urlEncode(os)
+        else
+            multipartEncode(os)
+    }
+
+    - const func urlEncodedSize() {
+        var size = _data.size() - 1 /* & by size-1 */
+        for (const item: _data) {
+            size += (
+                  1 /* = */
+                + base64.urlEncodeSize(item.0.size())
+                + base64.urlEncodeSize(item.1.size())
+            )
+        }
+
+        return size
+    }
+
+    - const func multipartEncodeSize(): !u64 {
+        var size = 0 as u64
+        for (const item: _data) {
+            size += (
+                2 /*--*/
+              + _boundary.size()
+              + 8 /* 4 * CRLF */
+              + CONTENT_DISPOSITION.size()
+              + 1 /* +1 for the last '"' */
+              + item.0.size()
+              + item.1.size()
+            )
+        }
+
+        if (_uploads.empty()) {
+            size += ( 4 /* 2 * -- */ + _boundary.size())
+            return size
+        }
+
+        for (const item, _: _uploads) {
+            size += (
+                  2 /* -- */
+                + _boundary.size()
+                + 4 /* 2 * CRLF */
+                + CONTENT_DISPOSITION.size()
+                + item.name().size()
+                + CONTENT_DISPOSITION_FILENAME.size()
+                + item.path().name().size()
+                + 1 /* '"' */
+            )
+
+            if (!item.contentType().empty())
+                size += (CONTENT_TYPE.size() + item.contentType().size() + 2 /* CRLF */ )
+            size += 2 /* CRLF */
+            size += (item.size() + 2 /* CRLF */ )
+        }
+
+        size +=  (
+              4 /* 2 * -- */
+            + _boundary.size()
+        )
+        return size
+    }
+
+    - const func size(): !u64 {
+        if (_data.empty() && _uploads.empty())
+            return 0 as u64
+        if (_encoding == .UrlEncode)
+            return urlEncodedSize()
+        else
+            return multipartEncodeSize()
+    }
+}
+
+pub class Request {
+    - _headers = HeaderMap();
+    - _args = HashMap[String, String]();
+    - _form: Form? = null;
+    - _body: String = null;
+    - _sendFile: SendFile? = null;
+    - _method = Method.Get;
+    - _resource = __string("");
+
+    @inline
+    - func `init`() {}
+
+    @inline
+    func header(name: String, value: String) => _headers.[&&name] = &&value
+
+    @inline
+    func arg(name: String, value: String) => _args.[&&name] = &&value
+
+    func body(value: String = null): !&String {
+        if (_form)
+            raise HttpError("Request body already set as a form")
+        else if (_sendFile)
+            raise HttpError("Request body already set as a file")
+        if (_body == null)
+            _body = (value == null? String() : &&value)
+        return &_body
+    }
+
+    @inline
+    func setContentType(value: String) => _headers.["Content-Type"] = &&value
+
+    func setForm(fm: Form): !void {
+        if (_body != null)
+            raise HttpError("Request body already set as a string buffer")
+        else if (_sendFile)
+            raise HttpError("Request body already set as a file")
+        else if (_form)
+            raise HttpError("Request form already set")
+
+        if (fm._encoding == .UrlEncode) {
+            setContentType("application/x-www-form-url-encoded")
+        }
+        else {
+            var contentType = "multipart/form-data; boundary=".S;
+            contentType << fm._boundary
+            setContentType(&&contentType)
+        }
+
+        _form = &&fm
+    }
+
+    func setFile(path: Path, contentType: String): !void {
+        if (_body != null)
+            raise HttpError("Request body already set as a string buffer")
+        else if (_form)
+            raise HttpError("Request body already set as a form")
+        else if (_sendFile)
+            raise HttpError("Request file already set")
+        var fd = os.open(path.__str())
+        var size = fd.size();
+        _sendFile = SendFile(&&fd, size)
+        setContentType(&&contentType)
+    }
+
+    func cleanup() {
+        _args.clear()
+        _headers.clear()
+        _form = null
+        _body = null
+        _sendFile = null
+        _resource = __string();
+    }
+
+    func reset(method: Method, resource: __string, clear: bool) {
+       if (clear || method != _method || _resource != resource) {
+            cleanup()
+            _resource = &&resource
+            _method = method
+       }
+    }
+
+    const func contentLength(): !u64 {
+        if (_body != null)
+            return _body.size()
+        if (_form)
+           return _form&.size()
+        if (_sendFile)
+            return _sendFile&.count
+        return 0 as u64
+    }
+
+    const func encodeHeaders(os: &BufferedSocketOutputStream) {
+        for (const hdr: _headers) {
+            os << hdr.0 << ": " << hdr.1 << CRLF!
+        }
+    }
+
+    const func encodeArgs(os: &BufferedSocketOutputStream) {
+        if (_args.empty())
+            return;
+        os << '?'
+        var first = true
+        for (const arg: _args) {
+            if (!first)
+                os << '&'
+            urlEncode(os, arg.0.__str())
+            os << '='
+            urlEncode(os, arg.1.__str())
+            first = false
+        }
+    }
+
+    func submit(sock: Socket, timeout: u64 = 0): !void {
+        var sos = BufferedSocketOutputStream(&&sock, timeout);
+        sos << _method << " "
+        if (_resource.empty())
+            sos << "/"
+        else
+            sos << _resource
+        encodeArgs(&sos)
+        sos << " HTTP/1.1" << CRLF!
+        encodeHeaders(&sos)
+        var size = contentLength();
+        if (size > 0)
+            sos << "Content-Length: " << size << CRLF!
+        sos << "Date: " << Time() << CRLF!
+        sos << CRLF!
+
+        if (size == 0)
+            return
+
+        if (_body != null) {
+            // Send body as it is
+            sos << _body
+        }
+        else if (_sendFile) {
+            // Send the file
+            sos.sendFile(_sendFile&.raw(), _sendFile&.count, 0)
+        }
+        else if (_form) {
+            // Encode the for
+            _form&.encode(&sos)
+        }
+        sos << CRLF!
+    }
+}
+
+type WriterFn = func(buf: ^const char, size: u64) -> bool
+
+pub class Response {
+    - _status: Status;
+    - _headers = HeaderMap();
+    - _writer: lambda_of!(#WriterFn);
+    - _body: String = null;
+    - _parser: ^parser.llhttp_t = null;
+    - _s1: String = null;
+    - _s2: String = null;
+    - _isComplete = false;
+
+    @inline
+    func `init`(settings: ^const parser.llhttp_settings_t) {
+        _parser = parser.llhttp_alloc(parser.llhttp_type_t.HTTP_RESPONSE, settings)
+        _parser.data = this
+    }
+
+    @inline
+    func `init`(settings: ^const parser.llhttp_settings_t, fn: WriterFn) {
+        this.op__init(settings)
+        _writer = &&fn
+    }
+
+    func `deinit`() {
+        if (_parser != null) {
+            parser.llhttp_free(_parser)
+            _parser = null
+        }
+    }
+
+    @[inline, prop]
+    const func ok() => _parser.status_code == Status.Ok
+
+    @[inline, prop]
+    const func statusCode() => _parser.status_code
+
+    @[prop, inline]
+    const func contentLength() => _parser.content_length
+
+    @[prop]
+    const func body() => &_body
+
+    @inline
+    func header(name: String, value: String) => _headers.[&&name] = &&value
+
+    func onBodyPart(buf: ^const char, len: u64): i32 {
+        if (_writer != null) {
+            // Write the body to the writer
+            return _writer(buf, len)? (-1 as i32) : 0
+        }
+        else if (_body == null) {
+            _body = String(buf, len)
+        }
+        else {
+            _body << __string(buf !: string, len)
+        }
+        return 0
+    }
+
+    func onHeadersComplete(): i32 {
+        if (_writer != null)
+            return 0
+
+        // invoke _writer with null and contentLength to initialized
+        if (_writer(null, contentLength()))
+            return 0
+        return -1
+    }
+
+    func onMessageComplete(): i32 {
+        if (_writer != null) {
+            // notify writer that message os complete
+            _writer(null, 0)
+        }
+        return 0
+    }
+
+    func feed(buf: ^const char, len: u64): bool {
+        const ret = parser.llhttp_execute(_parser, buf !: ^const char, len)
+        if (ret != parser.llhttp_errno.HPE_OK) {
+            const s = parser.llhttp_errno_name(ret) !: string
+            const reason = parser.llhttp_get_error_reason(_parser) !: string;
+            DBG!("parsing request failed - error: " << s << ", reason: " << reason )
+            return false
+        }
+        return true
+    }
+
+    func receive(sock: &Socket, timeout: u64): !void {
+        var buffer: [char, 8192] = []
+        while (!_isComplete) {
+            var count = sock.receive(buffer, sizeof!(buffer), timeout);
+            if (!count)
+                raise HttpError(f"Receiving fetch response failed: ${strerr()}")
+            if (!feed(buffer, *count)) {
+                const err = parser.llhttp_get_error_reason(_parser) !: string
+                raise HttpError(f"Parsing fetch response failed: ${err}")
+            }
+        }
+    }
+}
+
+func responseParserOnHeaderField(p: ^parser.llhttp_t, at: ^const char, len: u64) {
+    var resp = p.data !: Response;
+    if (resp._s2 != null) {
+        // We have seen a new header
+        assert!(resp._s1 != null)
+        resp._headers.[&&resp._s1] = &&resp._s2
+        resp._s1 = null
+        resp._s2 = null
+    }
+    if (resp._s1 == null) {
+        resp._s1 = String(at, len)
+    }
+    else {
+        resp._s1 << __string(at !: string, len)
+    }
+    return 0 as i32
+}
+
+func responseParserOnHeaderValue(p: ^parser.llhttp_t, at: ^const char, len: u64) {
+    var resp = p.data !: Response;
+    assert!(resp._s1 != null)
+    if (resp._s2 == null) {
+        resp._s2 = String(at, len)
+    }
+    else {
+        resp._s2 << __string(at !: string, len)
+    }
+    return 0 as i32
+}
+
+func responseParserOnHeadersComplete(p: ^parser.llhttp_t) {
+    var resp = p.data !: Response;
+    if (resp._s1 != null) {
+        assert!(resp._s1 != null)
+        resp._headers.[&&resp._s1] = &&resp._s2
+        resp._s1 = null
+        resp._s2 = null
+    }
+    return 0
+}
+
+func responseParserOnBody(p: ^parser.llhttp_t, at: ^const char, len: u64) {
+    var resp = p.data !: Response;
+    return resp.onBodyPart(at, len)
+}
+
+func responseParserOnMessageComplete(p: ^parser.llhttp_t) {
+    var resp = p.data !: Response;
+    resp._isComplete = true;
+    return 0
+}
+
+const HTTP_PARSER_SETTINGS = parser.llhttp_settings_t{
+    on_header_field: responseParserOnHeaderField,
+    on_header_value: responseParserOnHeaderValue,
+    on_headers_complete: responseParserOnHeadersComplete,
+    on_body: responseParserOnBody,
+    on_message_complete: responseParserOnMessageComplete
+};
+
+type RequestBuilder = func(req: &Request) -> !void
+
+class Session {
+    - _port = 80 as u16;
+    - _headers = HeaderMap();
+    - _timeout = 20000 as u64; /* 20 sec */
+    - _addr = Address();
+    - _proto = __string("http");
+    - _sock: Socket = null;
+    - _req: Request = null;
+
+    func `init`(proto: __string, host: String, port: u16, addr: Address) {
+        _proto = &&proto
+        _port = port
+        _addr = &&addr
+        header("Host", &&host)
+    }
+
+    @inline
+    func isHttps() => _proto == "https".s
+
+    @inline
+    func header(name: String, value: String): void { _headers.[&&name] = &&value }
+
+    @inline
+    func language(lang: String) { header("Accept-Language", &&lang) }
+
+    @inline
+    func userAgent(agent: String) { header("User-Agent", &&agent) }
+
+    func perform(
+        method: Method,
+        resource: __string,
+        builder: RequestBuilder = null,
+        writer: WriterFn = null
+    ): !Response {
+        if (_req == null)
+            _req = Request()
+        _req.reset(method, &&resource, false)
+        for (var hdr: _headers) {
+            _req.header(hdr.0, hdr.1)
+        }
+
+        if (builder != null) {
+            // Invoke request builder
+            builder(&_req)
+        }
+
+        @unlikely if (_sock == null || !_sock) {
+            var fd = tcpConnect(_addr, _timeout)
+            if (isHttps())
+                _sock = SslSocket.create(fd, _addr)
+            else
+                _sock = TcpSocket(fd, _addr)
+        }
+        // Submit request
+        _req.submit(_sock, _timeout)
+        var resp: Response = Response(ptrof HTTP_PARSER_SETTINGS, &&writer);
+        resp.receive(&_sock, _timeout)
+        return &&resp
+    }
+
+    func connect(hdrs: &const HeaderMap): !void {
+        var resp = perform(Method.Connect,  "/", (req: &Request): !void => {
+            if (hdrs != null) {
+                for (const hdr: hdrs) {
+                    req.header(hdr.0, hdr.1)
+                }
+            }
+        })
+
+        if (!resp.ok())
+            raise HttpError(
+                f".Connect to server '${_addr}' failed (status: ${resp.statusCode()}"
+            )
+        _req.cleanup()
+    }
+
+    @inline
+    func connect(): !void {
+        var hdrs: HeaderMap = null;
+        connect(&hdrs)
+    }
+
+    func head(resource: __string, hdrs: &const HeaderMap): !Response {
+        return perform(Method.Head, &&resource, (req: &Request): !void => {
+            for (const hdr: hdrs) {
+                req.header(hdr.0, hdr.1)
+            }
+        })
+    }
+
+    @inline
+    func head(resource: __string): !Response {
+        var hdrs: HeaderMap = null;
+        return head(&&resource, &hdrs)
+    }
+
+    @static
+    func create(url: __string) {
+        var idx = url.find("://")
+        var host = url;
+        var proto = "http".s
+        var port  = 80 as u16
+
+        if (idx) {
+            proto = url.substr(0, <i64>*idx)
+            host = url.substr(*idx + 3)
+        }
+
+        idx = host.rIndexOf(':' as char)
+        if (idx) {
+            port = host.substr(*idx + 1).toi[u16]()
+            host = host.substr(0, <i64>*idx)
+        }
+        else if(proto == "https".s) {
+            port = 443
+        }
+        var hostStr = String(host)
+        var addr = getRemoteAddress(hostStr.str(), port);
+        TRC1!(f"Connected to host: '${proto}://${host}:${port}'")
+        return This(proto, hostStr, port, &&addr)
+    }
+}
+
+pub func fetch(url: __string, builder: RequestBuilder = null): !Response {
+    var method = Method.Get
+    if (!url.empty() && url.[0] == '@' as char) {
+        var methodName = url.substr(1)
+        var ret = methodFromString(methodName)
+        if (ret.0 == .Unknown)
+            raise HttpError(f"Invalid fetch url '${url}', @METHOD in url is unknown")
+        var i = <i64>ret.1
+        while (true) {
+            if (!isSpace!(methodName.[i]))
+                break
+            i++
+        }
+        url = methodName.substr(i)
+        method = ret.0
+    }
+
+    var idx = url.find("://")
+    var resource = "/".s
+    if (idx) {
+        var stem = url.substr(*idx + 3)
+        var idx2 = stem.indexOf('/' as char)
+        if (idx2) {
+            resource = stem.substr(*idx2)
+            url = url.substr(0, <i64>(3 + *idx + *idx2))
+        }
+    }
+
+    var session = Session.create(url);
+    session.userAgent("Cxy/0.0.1")
+    return session.perform(method, resource, &&builder)
+}

--- a/src/cxy/stdlib/fserver.cxy
+++ b/src/cxy/stdlib/fserver.cxy
@@ -9,16 +9,17 @@ import { Path } from "stdlib/path.cxy"
 import { Request, Response, Server, Method, Status, SendFile } from "./http.cxy"
 
 import "unistd.h" as unistd
-import "stdlib.h" as stdlib
 import "sys/mman.h" as vmem
 
 ##if (defined MACOS) {
 import "sys/fcntl.h" as fcntl
 import "sys/syslimits.h" as limits // for PATH_MAX! macro)
+import "_stdlib.h" as stdlib
 }
 else {
 import "fcntl.h" as fcntl
 import "linux/limits.h" as limits // for PATH_MAX! macro
+import "stdlib.h" as stdlib
 }
 
 #if (defined MACOS) {
@@ -34,10 +35,10 @@ macro StatField(X) mk_ident!("st_", X!, "tim")
 
 @json
 pub struct Config {
-    compressMin = 2048:u64;
+    compressMin = 2048 as u64;
     enableSendFile = false;
-    cacheExpires = 86400:i64;
-    mappedMin = 2048:u64;
+    cacheExpires = 86400 as i64;
+    mappedMin = 2048 as u64;
     root = String("./www/");
     route = String(CXY_FILE_SERVER_ROUTE!);
     allowRange = true;
@@ -47,14 +48,14 @@ struct CachedFile {
     fd: i32 = -1;
     data: ^void = null;
     path: String = null;
-    len = 0:u64;
-    size = 0:u64;
+    len = 0 as u64;
+    size = 0 as u64;
     lastMod: time_t = 0;
     lastAccess: time_t = 0;
     useFd = false;
     isMapped = false;
     valid = false;
-    flags = 0:u8;
+    flags = 0 as u8;
 
     func `init`() {}
 
@@ -92,7 +93,7 @@ struct MimeConfig {
     allowCompress = false;
     allowCaching = true;
     allowRange = true;
-    cacheExpires = -1:i64;
+    cacheExpires = -1 as i64;
 }
 
 struct MimeType {
@@ -134,7 +135,7 @@ pub class FileServer {
                 path = __copy!(rootAlias)
             }
 
-            var idx = path.rIndexOf('.':char)
+            var idx = path.rIndexOf('.' as char)
             if (!idx) {
                 var aliasedPath = this.redirects.[path]
                 if (!aliasedPath) {
@@ -143,7 +144,7 @@ pub class FileServer {
                 }
                 var tmp = *aliasedPath;
                 path = __copy!(tmp)
-                idx =  path.rIndexOf('.':char)
+                idx =  path.rIndexOf('.' as char)
             }
             var pathOpt = this.fileExists(&path);
             if (!pathOpt) {
@@ -246,7 +247,7 @@ pub class FileServer {
     }
 
     func alias(src: String, dst: String) : void {
-        if (!dst.rIndexOf('.':char)) {
+        if (!dst.rIndexOf('.' as char)) {
             ERR!( "redirecting '" << src << "' to unsupported file format: '" << dst << "'" )
             assert!(false)
         }
@@ -327,7 +328,7 @@ pub class FileServer {
             return buildRangeResponse(resp, *rng, cf);
         }
         else {
-            if (config.enableSendFile)
+            if (cf.useFd)
                 resp.chunk(SendFile(FileDescriptor(cf.fd), cf.len))
             else
                 resp.chunk(__string(cf.data !: string, cf.len))
@@ -340,17 +341,17 @@ pub class FileServer {
         rng: &const String,
         cf: &CachedFile
     ) : Status {
-        var i = 0:i64;
-        var j = 0:i64;
+        var i = 0 as i64;
+        var j = 0 as i64;
         var s = rng.__str();
         var ranges = Vector[(i64, i64)]();
         while (i < s.size()) {
             // Skip white-space
-            while(s.[i] == ' ':char) i++;
+            while(s.[i] == ' ' as char) i++;
             var start = s.toi[i64]();
             var end: i64;
             s = s.substr(j)
-            var tmp = s.indexOf('-':char);
+            var tmp = s.indexOf('-' as char);
             if (tmp) {
                 i = <i64> *tmp
                 s = s.substr(i+1)
@@ -368,7 +369,7 @@ pub class FileServer {
             }
             ranges.push((start, end))
 
-            tmp = s.indexOf(',':char)
+            tmp = s.indexOf(',' as char)
             if (tmp) {
                 i = (<i64> *tmp + 1)
             }
@@ -377,7 +378,7 @@ pub class FileServer {
         // depending on the number of requested ranges, build Response
         if (ranges.size() == 1) {
             var rng = ranges.[0];
-            if (config.enableSendFile)
+            if (cf.useFd)
                 resp.chunk(SendFile(FileDescriptor(cf.fd), rng.0, rng.1))
             else
                 resp.chunk(__string(cf.data !: string, cf.len).substr(rng.0, rng.1))
@@ -497,7 +498,7 @@ pub class FileServer {
             var total = s.st_size;
             total += SysConfPageSize - (total % SysConfPageSize)
             cf.data = vmem.mmap(null, total, PROT_READ!, MAP_SHARED!, cf.fd, 0)
-            if (cf.data == ((-1:u64) !: ^void)) {
+            if (cf.data == ((-1 as u64) !: ^void)) {
                 WRN!("mapping static resource (" << cf.fd << ") of size " << total << " failed: " << errno!);
                 return false;
             }
@@ -507,7 +508,7 @@ pub class FileServer {
         else {
             // read file
             var total = s.st_size + 8;
-            var nread = 0:u64;
+            var nread = 0 as u64;
             var toread = s.st_size;
             var b = malloc(total) !: ^char;
              while (nread < toread) {

--- a/src/cxy/stdlib/hash.cxy
+++ b/src/cxy/stdlib/hash.cxy
@@ -2,11 +2,11 @@ module hash
 
 import { Vector } from "stdlib/vector.cxy"
 
-macro HMAP_PRIMES_COUNT = 24:u64
+macro HMAP_PRIMES_COUNT = 24 as u64
 macro HMAP_LOAD_FACTOR = 0.9
 
 const HMAP_RIMES: [u64, HMAP_PRIMES_COUNT!] = [
-    0:u64,     1,      5,      11,     23,      53,      101,     197,
+    0 as u64,     1,      5,      11,     23,      53,      101,     197,
     389,   683,    1259,   2417,   4733,    9371,    18617,   37097,
     74093, 148073, 296099, 592019, 1100009, 2200013, 4400021, 8800019
 ];
@@ -98,7 +98,7 @@ pub class HashMap[K, V, Hasher = Hash[K], Cmp = Equals[K]] {
         }
 
         var i = Hasher{}(&item.key) % _capacity
-        var j = 0:u64;
+        var j = 0 as u64;
         item.hash = i + 1
         while (true) {
             const h = _data.[i].hash
@@ -131,7 +131,7 @@ pub class HashMap[K, V, Hasher = Hash[K], Cmp = Equals[K]] {
             return null
 
         var i = Hasher{}(&key) % _capacity
-        var j = 0:u64
+        var j = 0 as u64
 
         while (true) {
             var h = _data.[i].hash
@@ -151,7 +151,7 @@ pub class HashMap[K, V, Hasher = Hash[K], Cmp = Equals[K]] {
             return null
 
         var i = Hasher{}(&key) % _capacity
-        var j = 0:u64
+        var j = 0 as u64
 
         while (true) {
             var h = _data.[i].hash
@@ -238,6 +238,9 @@ pub class HashMap[K, V, Hasher = Hash[K], Cmp = Equals[K]] {
     @inline
     const func capacity() => _capacity
 
+    @inline
+    const func empty() => _size == 0
+
     #if (#V != #void) {
         func insert(key: K, value: V, replace: bool = true) {
             var data = HashMapNode[K, V]{key: &&key, value: &&value}
@@ -286,6 +289,20 @@ pub class HashMap[K, V, Hasher = Hash[K], Cmp = Equals[K]] {
             }
         }
 
+        const func `..`() {
+            var i = 0;
+            return () : (K, V)? => {
+                while (i < _capacity) {
+                    if (_data.[i].hash != 0) {
+                        var j = i++
+                        return (_data.[j].key, _data.[j].value)
+                    }
+                    i++
+                }
+                return null
+            }
+        }
+
         func each(fun: func(key: K, value: V) -> void) {
             var i = 0
             while (i < _capacity) {
@@ -314,6 +331,20 @@ pub class HashMap[K, V, Hasher = Hash[K], Cmp = Equals[K]] {
         }
 
         func `..`() {
+            var i = 0;
+            return () : K? => {
+                while (i < _capacity) {
+                    if (_data.[i].hash != 0) {
+                        var j = i++
+                        return _data.[j].key
+                    }
+                    i++
+                }
+                return null
+            }
+        }
+
+        const func `..`() {
             var i = 0;
             return () : K? => {
                 while (i < _capacity) {

--- a/src/cxy/stdlib/http.cxy
+++ b/src/cxy/stdlib/http.cxy
@@ -7,13 +7,11 @@ import { Vector } from "./vector.cxy"
 import { HashMap } from "./hash.cxy"
 import { Trie } from "./trie.cxy"
 
-import { Address } from "./net.cxy"
-import { TcpSocket, TcpListener, BufferedSocketOutputStream } from "./tcp.cxy"
+import { Address, BufferedSocketOutputStream } from "./net.cxy"
+import { TcpSocket, TcpListener } from "./tcp.cxy"
 import { Thread } from "./thread.cxy"
 
-@__cc "native/http/api.c"
-@__cc "native/http/http.c"
-@__cc "native/http/llhttp.c"
+import "./native/http/index.cxy"
 
 ##if (defined MACOS) {
     import "_ctype.h" as ctype
@@ -30,13 +28,21 @@ import "native/http/llhttp.h" as parser
 pub exception HttpError(msg: String) => msg == null? "" : msg.str()
 
 pub enum Method : u32 {
+    @str("DELETE")
     Delete,
+    @str("GET")
     Get,
+    @str("HEAD")
     Head,
+    @str("POST")
     Post,
+    @str("PUT")
     Put,
+    @str("CONNECT")
     Connect,
+    @str("OPTIONS")
     Options,
+    @str("TRACE")
     Trace,
     Unknown
 }
@@ -92,29 +98,30 @@ pub func methodFromString(method: __string) {
     var maybe = (Method.Unknown, "");
 
     switch(x) {
-        case 'D':char => maybe = (Method.Delete, "DELETE")
-        case 'G':char => maybe = (Method.Get, "GET")
-        case 'H':char => maybe = (Method.Head, "HEAD")
-        case 'P':char => {
-            if (toupper(method.[1]) == 'O':char)
+        case 'D' as char => maybe = (Method.Delete, "DELETE")
+        case 'G' as char => maybe = (Method.Get, "GET")
+        case 'H' as char => maybe = (Method.Head, "HEAD")
+        case 'P' as char => {
+            if (toupper(method.[1]) == 'O' as char)
                 maybe = (Method.Post, "POST")
             else
                 maybe = (Method.Put, "PUT")
         }
-        case 'C':char => maybe = (Method.Connect, "CONNECT")
-        case 'O':char => maybe = (Method.Options, "OPTIONS")
-        case 'T':char => maybe = (Method.Trace, "TRACE")
-        default  => return (Method.Unknown, 0:u64)
+        case 'C' as char => maybe = (Method.Connect, "CONNECT")
+        case 'O' as char => maybe = (Method.Options, "OPTIONS")
+        case 'T' as char => maybe = (Method.Trace, "TRACE")
+        default  => return (Method.Unknown, 0 as u64)
     }
 
     var str = __string(maybe.1);
     if (method.size() < str.size())
-        return (Method.Unknown, 0:u64)
+        return (Method.Unknown, 0 as u64)
 
+    method = method.substr(0, <i64>str.size())
     if (EqualsCase{}(&method, &str))
         return (maybe.0, str.size())
 
-    return (Method.Unknown, 0:u64)
+    return (Method.Unknown, 0 as u64)
 }
 
 pub func statusText(status: Status) {
@@ -227,7 +234,7 @@ pub func methodName(method: Method) {
     }
 }
 
-type HeaderMap = HashMap[String, String, HashCase, EqualsCase];
+pub type HeaderMap = HashMap[String, String, HashCase, EqualsCase];
 pub var CONTENT_LENGTH_S = String("Content-Length");
 pub var CONTENT_LENGTH_CS = __string("Content-Length");
 pub var DATE_S = String("Date");
@@ -343,7 +350,7 @@ pub class Response {
             return _body.size()
         if (_chunks == null)
             return 0
-        var sz = 0:u64;
+        var sz = 0 as u64;
         for (const chunk, _: _chunks) {
             match (chunk) {
                 case string as s => sz += len!(s)
@@ -400,6 +407,7 @@ pub class Request {
     - _s2: String = null;
     - _isComplete = false;
     - _parser: ^parser.llhttp_t = null;
+    - _middlewareContexts: ^void = null;
     - _route: &Route
 
     @inline
@@ -430,14 +438,14 @@ pub class Request {
     @[prop, inline]
     const func method() {
         switch(_parser.method) {
-            case 0:u8 /* HTTP_DELETE */ => return Method.Delete
-            case 1:u8 /* HTTP_GET */ => return Method.Get
-            case 2:u8 /* HTTP_HEAD */ => return Method.Head
-            case 3:u8 /* HTTP_POST */ => return Method.Post
-            case 4:u8 /* HTTP_PUT */ => return Method.Put
-            case 5:u8 /* HTTP_CONNECT */ => return Method.Connect
-            case 6:u8 /* HTTP_OPTIONS */ => return Method.Options
-            case 7:u8 /* HTTP_TRACE */ => return Method.Trace
+            case 0 as u8 /* HTTP_DELETE */ => return Method.Delete
+            case 1 as u8 /* HTTP_GET */ => return Method.Get
+            case 2 as u8 /* HTTP_HEAD */ => return Method.Head
+            case 3 as u8 /* HTTP_POST */ => return Method.Post
+            case 4 as u8 /* HTTP_PUT */ => return Method.Put
+            case 5 as u8 /* HTTP_CONNECT */ => return Method.Connect
+            case 6 as u8 /* HTTP_OPTIONS */ => return Method.Options
+            case 7 as u8 /* HTTP_TRACE */ => return Method.Trace
             default => return Method.Unknown
         }
     }
@@ -479,6 +487,9 @@ pub class Request {
         _uri = it
     }
 
+    @[inline, prop]
+    const func middlewareContexts() => _middlewareContexts
+
     func clear() {
         _headers.clear()
         _params.clear()
@@ -507,7 +518,7 @@ pub class Request {
 func requestParserOnMessageBegin(p: ^parser.llhttp_t) {
     var req = p.data !: Request;
     req.clear()
-    return 0:i32
+    return 0 as i32
 }
 
 func requestParserOnUrl(p: ^parser.llhttp_t, at: ^const char, len: u64) {
@@ -518,7 +529,7 @@ func requestParserOnUrl(p: ^parser.llhttp_t, at: ^const char, len: u64) {
     else {
         req._path << __string(at !: string, len)
     }
-    return 0:i32
+    return 0 as i32
 }
 
 func requestParserOnHeaderField(p: ^parser.llhttp_t, at: ^const char, len: u64) {
@@ -536,7 +547,7 @@ func requestParserOnHeaderField(p: ^parser.llhttp_t, at: ^const char, len: u64) 
     else {
         req._s1 << __string(at !: string, len)
     }
-    return 0:i32
+    return 0 as i32
 }
 
 func requestParserOnHeaderValue(p: ^parser.llhttp_t, at: ^const char, len: u64) {
@@ -548,7 +559,7 @@ func requestParserOnHeaderValue(p: ^parser.llhttp_t, at: ^const char, len: u64) 
     else {
         req._s2 << __string(at !: string, len)
     }
-    return 0:i32
+    return 0 as i32
 }
 
 func requestParserOnHeadersComplete(p: ^parser.llhttp_t) {
@@ -597,13 +608,13 @@ pub struct RouteAttrs {
 
 class Route {
     - prefix: __string
-    - handler: Lambda[HandlerFn]
+    - handler: lambda_of!(#HandlerFn)
     - params: Vector[__string]
     - _methods: u32
     - _attrs = RouteAttrs{};
 
     func `init`(methods: u32, prefix: __string, fn: HandlerFn, params: Vector[__string]) {
-        handler = Lambda[HandlerFn](fn)
+        handler = &&fn
         this.prefix = prefix
         this.params = &&params
         _methods = methods
@@ -634,7 +645,7 @@ class Route {
     const func `str`(os: &OutputStream) { os << "route: " << prefix }
 
     @inline
-    const func isMethodSupported(method: Method) => (_methods & (1:u32 << (<u32>method))) != 0
+    const func isMethodSupported(method: Method) => (_methods & (1 as u32 << (<u32>method))) != 0
 
     @inline
     const func attrs() => &_attrs
@@ -649,13 +660,13 @@ class Router {
     }
 
     - func add(methods: u32, path: string, idx: i64, fn: HandlerFn) {
-        assert!(path.[idx] == '/':char)
+        assert!(path.[idx] == '/' as char)
         var i = idx;
-        while (path.[i] != '\0':char && path.[i] != '{':char) {
+        while (path.[i] !=  '\0'as char && path.[i] != '{' as char) {
             i++
         }
 
-        if (path.[i] == '{':char)
+        if (path.[i] == '{' as char)
             i--;
         var prefix = __string(path, i).substr(idx);
         var params = Vector[__string]();
@@ -667,13 +678,13 @@ class Router {
 
     func add(path: string, fn: HandlerFn) {
         var methods = Method.Get;
-        var idx = 0:i64;
-        if (path.[0] != '/':char) {
+        var idx = 0 as i64;
+        if (path.[0] != '/' as char) {
             var parsedMethod = methodFromString(path);
             assert!(parsedMethod.0 != .Unknown)
             methods = parsedMethod.0
             idx = <i64>parsedMethod.1;
-            while (path.[idx] == ' ':char)
+            while (path.[idx] == ' ' as char)
                 idx++
         }
 
@@ -745,13 +756,13 @@ class Router {
 
     - func parseParams(params: &Vector[__string], path: string, idx: i64) : void {
         var s = path !: ^const char;
-        while (path.[idx] == '/':char) {
+        while (path.[idx] == '/' as char) {
             idx++
-            assert!(path.[idx++] == '{':char)
+            assert!(path.[idx++] == '{' as char)
             var i = idx;
-            while (path.[i] != '\0':char && path.[i] != '}':char)
+            while (path.[i] !=  '\0'as char && path.[i] != '}' as char)
                 i++
-            assert!(path.[i] == '}':char)
+            assert!(path.[i] == '}' as char)
             var name = __string(ptroff!(s + idx) !: string, i - idx);
             idx = i + 1
             params.push(name)
@@ -760,21 +771,21 @@ class Router {
 
     - func parseRouteArgs(req: &Request, params: &Vector[__string], path: __string) : u64 | Status {
         var p = path.data();
-        var idx = 0:u64;
+        var idx = 0 as u64;
         for (var i: 0..params.size()) {
-            if (p.[idx++] != '/':char) {
+            if (p.[idx++] != '/' as char) {
                 TRC!("bad request: route missing parameters")
                 return Status.BadRequest
             }
             var j = idx;
-            while (p.[j] != '\0':char && p.[j] != '/':char && p.[j] != '?':char)
+            while (p.[j] !=  '\0' as char && p.[j] != '/' as char && p.[j] != '?' as char)
                 j++;
             var value = __string(ptroff!(p + idx) !: string, j - idx);
             idx = j;
             req.param(<__string>params.[<i32>i], value)
         }
 
-        if (p.[idx] != '\0':char && p.[idx] != '?':char) {
+        if (p.[idx] !=  '\0'as char && p.[idx] != '?' as char) {
             TRC!("bad request: too many path params: " << path)
             return Status.BadRequest
         }
@@ -787,11 +798,36 @@ class Router {
 pub struct Config {
     - address = Address("0.0.0.0", 8100);
     - serverName = String("cxy");
-    - hstsEnable = 5000:u64;
-    - keepAliveTime = 5000:i64;
+    - hstsEnable = 5000 as u64;
+    - keepAliveTime = 5000 as i64;
+}
+
+pub struct Dependencies[T] {
+    type TDeps = `T as M,i => &M.Context`;
+    contexts: TDeps;
+
+    @inline func `init`(){}
+
+    - func init[Mws, Contexts](ctxs: &Contexts) {
+        #const WithContexts = #`Mws as U,i => U, has_type!(U, :Context)`
+        #for (const i: 0..T.membersCount) {
+            #const Mw = typeat!(#T, i);
+            #const idx = indexof!(#WithContexts, #Mw);
+            require!(idx >= 0, "Dependency {t} must exist in list of middlewares {t} with contexts",
+                     #WithContexts, #Mw)
+            contexts.#{i} = &ctxs.#{idx}
+        }
+    }
+
+    func context[M]() {
+        #const idx = indexof!(#T, #M);
+        require!(idx >= 0, "Middleware {t} is not in the list of dependencies {t}", #M, #T)
+        return contexts.#{idx}
+    }
 }
 
 pub class Connection[Middlewares] {
+    type Contexts = `Middlewares as T, i => T.Context, has_type!(#T, :Context)`
     @static
     - LOG_TAG = "HTTP_CONNECTION";
     - sock: TcpSocket
@@ -843,14 +879,41 @@ pub class Connection[Middlewares] {
 
     - func invokeRouteHandler(route: &Route) : void {
         req.route(route)
+        var ctxs: Contexts = null;
+        @unused var deps: `Middlewares as T,i => Dependencies[T.Deps], has_type!(#T, :Deps)` = null;
+        #const j = 0;
         #for (const i: 0..Middlewares.membersCount) {
             // invoke middlewares
-            mws.#{i}.before(&req, &resp)
-            defer mws.#{i}.after(&req, &resp)
+            #const M = typeat!(#Middlewares, i);
+            #if (has_type!(#M, :Deps)) {
+                deps.#{j}.init[Middlewares](&ctxs)
+                #if (has_type!(#M, :Context)) {
+                    #const idx = indexof!(#Contexts, M.Context);
+                    ctxs.#{idx} = M.Context()
+                    mws.#{i}.before(&req, &resp, &ctxs.#{idx}, &deps.#{j})
+                    defer mws.#{i}.after(&req, &resp, &ctxs.#{idx}, &deps.#{j})
+                }
+                else {
+                    mws.#{i}.before(&req, &resp, &deps.#{j})
+                    defer mws.#{i}.after(&req, &resp, &deps.#{j})
+                }
+                #{j += 1}
+            }
+            else #if (has_type!(#M, :Context)) {
+                #const idx = indexof!(#Contexts, M.Context);
+                ctxs.#{idx} = M.Context()
+                mws.#{i}.before(&req, &resp, &ctxs.#{idx})
+                defer mws.#{i}.after(&req, &resp, &ctxs.#{idx})
+            }
+            else {
+                mws.#{i}.before(&req, &resp)
+                defer mws.#{i}.after(&req, &resp)
+            }
             if (resp.isComplete())
                 return;
         }
         // handle route
+        req._middlewareContexts = ptrof ctxs
         route(&req, &resp)
     }
 
@@ -920,6 +983,8 @@ pub class Connection[Middlewares] {
 
 pub class Server[Middlewares] {
     require!(Middlewares.isTuple, "requires a tuple of middlewares")
+    type MwsWithContexts = `Middlewares as T, i => T, has_type!(#T, :Context)`
+    type Contexts = `MwsWithContexts as T, i => T.Context, has_type!(#T, :Context)`
     @static
     - LOG_TAG = "HTTP_SERVER";
     - mws: Middlewares
@@ -932,16 +997,54 @@ pub class Server[Middlewares] {
         #for (const i: 0..Middlewares.membersCount) {
             #const M = typeat!(#Middlewares, #{i});
             require!(M.isClass, "A middleware must be a class type")
-            require!(has_member!(#M, "before", #func(_: &const Request, _: &Response) -> void),
-                     "middle {t} must implement `before` handler of type {t}",
-                     #M, #func(_: &const Request, _: &Response) -> void)
-            require!(has_member!(#M, "after", #func(_: &const Request, _: &Response) -> void),
-                                 "middle {t} must implement `after` handler of type {t}",
-                                 #M, #func(_: &const Request, _: &Response) -> void)
-
             require!(has_member!(#M, "op__init", #func() -> void),
                                  "middle {t} must implement a default constructor",
                                  #M)
+            #const Others = #`Middlewares as T,j => T, j != i`;
+            require!(indexof!(#Others, #M) < 0, "Middleware `{t}` duplicated in list `{t}`",
+                     #M, #Middlewares)
+            #if (has_type!(#M, :Deps)) {
+                // Validate middleware dependencies
+                #const Deps = M.Deps;
+                #for(const j: 0..Deps.membersCount) {
+                    #const Dep =  typeat!(#Deps, j);
+                    require!(has_type!(#Dep, :Context), "Middle {t} dependency {t} must have a Context type",
+                             #M, #Dep)
+                    #const idx = indexof!(#Middlewares, #Dep);
+                    require!(idx >= 0, "Dependency {t} is not in the list of middlewares `{t}",
+                             #Dep, #Middlewares)
+                    require!(idx < i, "Dependency {t} must come before current middleware", #Dep)
+                }
+                #const DepsCtxs = Dependencies[Deps];
+                #if (has_type!(#M, :Context)) {
+                    #const Func = #func(_: &const Request, _: &Response, _: &M.Context, _: DepsCtxs) -> void;
+                    require!(has_member!(#M, "before", #Func),
+                             "middle {t} must implement `before` handler of type {t}", #M, #Func)
+                    require!(has_member!(#M, "after", #Func),
+                             "middle {t} must implement `after` handler of type {t}", #M, #Func)
+                }
+                else {
+                    #const Func = #func(_: &const Request, _: &Response, _: &DepsCtxs) -> void;
+                    require!(has_member!(#M, "before", #Func),
+                             "middle {t} must implement `before` handler of type {t}", #M, #Func)
+                    require!(has_member!(#M, "after", #Func),
+                             "middle {t} must implement `after` handler of type {t}", #M, #Func)
+                }
+            }
+            else #if (has_type!(#M, :Context)) {
+                #const Func = #func(_: &const Request, _: &Response, _: &M.Context) -> void;
+                require!(has_member!(#M, "before", #Func),
+                      "middle {t} must implement `before` handler of type {t}", #M, #Func)
+                require!(has_member!(#M, "after", #Func),
+                      "middle {t} must implement `after` handler of type {t}", #M, #Func)
+            }
+            else {
+                #const Func = #func(_: &const Request, _: &Response) -> void;
+                require!(has_member!(#M, "before", #Func),
+                      "middle {t} must implement `before` handler of type {t}", #M, #Func)
+                require!(has_member!(#M, "after", #Func),
+                      "middle {t} must implement `after` handler of type {t}", #M, #Func)
+            }
             mws.#{i} = #{M}()
         }
         // initialize other variables
@@ -955,6 +1058,14 @@ pub class Server[Middlewares] {
         #const idx = indexof!(#Middlewares, #M);
         require!(idx >= 0, "type '{t}' is not a middleware, middlewares: {t}", #M, #Middlewares)
         return mws.#{idx}
+    }
+
+    @inline
+    func context[M](req: &const Request) {
+        #const idx = indexof!(#MwsWithContexts, #M);
+        require!(idx >= 0, "type '{t}' is not a middleware or does not have a context", #M, #Middlewares)
+        var ctxs = req.middlewareContexts() !: ^Contexts
+        return ctxs.#{idx}
     }
 
     func listen(): !void {

--- a/src/cxy/stdlib/json.cxy
+++ b/src/cxy/stdlib/json.cxy
@@ -1,7 +1,7 @@
 module json
 import "./base64.cxy"
 
-macro EOS '\0':char
+macro EOS  '\0'as char
 
 pub func toJSON[T](os: &OutputStream, it: &const T) : void {
     #if (T.isChar) {
@@ -82,9 +82,9 @@ exception JSONParserError(msg: String) => (msg != null)? msg.str() : ""
 
 pub class JSONParser {
     - data: __string
-    - off = 0:u32;
-    - line = 1:u32;
-    - col = 1:u32;
+    - off = 0 as u32;
+    - line = 1 as u32;
+    - col = 1 as u32;
 
     func `init`(data: __string) {
         this.data = &&data
@@ -93,7 +93,7 @@ pub class JSONParser {
     func advance() {
         off++
         col++
-        if (data.[off] == '\n':char) {
+        if (data.[off] == '\n' as char) {
             line++
             col = 1
         }
@@ -121,23 +121,23 @@ pub class JSONParser {
     func expectString(): !__string {
         skipWhitespace();
 
-        if (data.[off] != '"':char)
+        if (data.[off] != '"' as char)
             raise JSONParserError(f"${line}:${col} - expecting a string start token '\"'")
 
         advance()
         var start = off;
         var p = data.str();
         while (!done() && p.[off] != EOS!) {
-            if (p.[off] == '\\':char && p.[off + 1] == '\"':char) {
+            if (p.[off] == '\\' as char && p.[off + 1] == '\"' as char) {
                 advance()
                 advance()
                 continue
             }
-            if (p.[off] == '\"':char)
+            if (p.[off] == '\"' as char)
                 break
             advance()
         }
-        if (p.[off] != '\"':char)
+        if (p.[off] != '\"' as char)
             raise JSONParserError(f"${line}:${col} - expecting a '\"' to terminate the string")
         var str = data.substr(start, off-start);
         advance()
@@ -171,18 +171,18 @@ pub class JSONParser {
         var l, c = (line, col);
         var start = off;
         var p = data.str();
-        if (p.[off] == '-':char)
+        if (p.[off] == '-' as char)
             advance()
         while (!done() && isDigit!(p.[off]))
             advance()
 
-        if (p.[off] == '.':char) {
+        if (p.[off] == '.' as char) {
             advance()
             while (!done() && isDigit!(p.[off]))
                 advance()
         }
 
-        if (p.[off] == 'E':char || p.[off] == 'e':char) {
+        if (p.[off] == 'E' as char || p.[off] == 'e' as char) {
             advance()
             if (!consumeChar('-'))
                 consumeChar('+')
@@ -231,9 +231,56 @@ pub class JSONParser {
     }
 
     @inline func tag() => (line, col)
+
+    func skipValue(): !void {
+        skipWhitespace()
+        if (data.[off] == '"' as char) {
+            expectString()
+        }
+        else if(data.[off] == 't' as char || data.[off] == 'f' as char) {
+            expectBool()
+        }
+        else if (data.[off] == 'n' as char) {
+            matchNull()
+        }
+        else if (isDigit!(data.[off])) {
+            expectFloat[f64]()
+        }
+        else if (consumeChar('{')) {
+            skipWhitespace()
+            while (data.[off] != '}' as char) {
+                expectString()
+                skipWhitespace()
+                expectChar(':')
+                skipValue()
+                skipWhitespace()
+                if (!consumeChar(','))
+                    break
+                skipWhitespace()
+            }
+            expectChar('}')
+        }
+        else if (consumeChar('[')) {
+            skipWhitespace()
+            while (data.[off] != ']' as char) {
+                skipValue()
+                skipWhitespace()
+                if (!consumeChar(','))
+                    break
+                skipWhitespace()
+            }
+            expectChar(']')
+        }
+    }
 }
 
-func fieldFromJSON[T](p: &JSONParser, pos: (u32, u32), obj: &T, key: &__string): !void {
+func fieldFromJSON[T](
+    p: &JSONParser,
+    pos: (u32, u32),
+    obj: &T,
+    key: &__string,
+    partialAllowed: bool
+): !void {
     #for(const member: T.members) {
         #if (member.isField) {
             #const M = member.Tinfo;
@@ -253,6 +300,12 @@ func fieldFromJSON[T](p: &JSONParser, pos: (u32, u32), obj: &T, key: &__string):
             }
         }
     }
+
+    if (partialAllowed) {
+       p.skipValue()
+       return
+    }
+
     const typeName = #{T.name};
     raise JSONParserError(f"${pos.0}:${pos.1} - Json key '${key}' does not exist in type '${typeName}'")
 }
@@ -292,13 +345,19 @@ func parseJSON[T](p: &JSONParser): !T {
             return &&tmp
         }
         else #if (T.isStruct && T.attributes.["json"]) {
+            #const attrs = T.attributes.["json"];
+            #const pa = attrs.["partial"];
             var tmp = T{};
             p.expectChar('{')
-            while (p.peekChar() != '}':char) {
+
+            while (p.peekChar() != '}' as char) {
                 var pos = p.tag();
                 var key = p.expectKey();
                 p.expectChar(':')
-                fieldFromJSON(p, pos, &tmp, &key)
+                #if (pa)
+                    fieldFromJSON(p, pos, &tmp, &key, true)
+                else
+                    fieldFromJSON(p, pos, &tmp, &key, false)
                 p.consumeChar(',')
             }
             p.expectChar('}')
@@ -323,7 +382,7 @@ pub func fromString[T](s: &const String): !T {
 
 test "Json encode" {
     var s = String();
-    toJSON(&s, 10:i32)
+    toJSON(&s, 10 as i32)
     ok!(s == "10")
 
     s.clear()
@@ -331,11 +390,11 @@ test "Json encode" {
     ok!(s == "{\"a\": 10, \"b\": true, \"c\": \"world\", \"d\": 99}")
 
     s.clear()
-    toJSON(&s, &(10:u32, true, "World"))
+    toJSON(&s, &(10 as u32, true, "World"))
     ok!(s == "[10, true, \"World\"]")
 
     s.clear()
-    toJSON(&s, &[10:u32, 20, 30])
+    toJSON(&s, &[10 as u32, 20, 30])
     ok!(s == "[10, 20, 30]")
 
     var x:i32? = 100;

--- a/src/cxy/stdlib/log.cxy
+++ b/src/cxy/stdlib/log.cxy
@@ -25,15 +25,19 @@ struct FixedWidth {
 
     @inline
     const func `str`(os: &OutputStream) {
-        os << s.substr(0:u64, <i64>min(count, s.size()))
+        os << s.substr(0 as u64, <i64>min(count, s.size()))
         if (s.size() < count)
             os << Repeat( ' ', count - s.size() )
     }
 }
 
+#if (!defined CXY_LOG_LEVEL) {
+    macro CXY_LOG_LEVEL = .TRACE
+}
+
 class Logger {
     - os: OutputStream;
-    - _level: Level = .DEBUG;
+    - _level: Level = CXY_LOG_LEVEL!;
 
     func `init`() {
         os = stdout
@@ -64,6 +68,29 @@ macro DBG(MSG) =( __LOG!(logger.Level.DEBUG, MSG!) )
 macro INF(MSG) =( __LOG!(logger.Level.INFO, MSG!) )
 macro WRN(MSG) =( __LOG!(logger.Level.WARNING, MSG!) )
 macro ERR(MSG) =( __LOG!(logger.Level.ERROR, MSG!) )
+
+#if (defined CXY_TRACE_LEVEL) {
+    #if (CXY_TRACE_LEVEL! == 3) {
+        macro TRC3(MSG) TRC!(MSG!)
+        macro TRC2(MSG) TRC!(MSG!)
+        macro TRC1(MSG) TRC!(MSG!)
+    }
+    else #if (CXY_TRACE_LEVEL! == 2) {
+        macro TRC3(MSG) ()
+        macro TRC2(MSG) TRC!(MSG!)
+        macro TRC1(MSG) TRC!(MSG!)
+    }
+    else #if (CXY_TRACE_LEVEL! == 1) {
+        macro TRC3(MSG) ()
+        macro TRC2(MSG) ()
+        macro TRC1(MSG) TRC!(MSG!)
+    }
+}
+else {
+    macro TRC3(MSG) ()
+    macro TRC2(MSG) ()
+    macro TRC1(MSG) ()
+}
 
 @inline
 pub func setLogLevel(lvl: Level) {

--- a/src/cxy/stdlib/native/http/index.cxy
+++ b/src/cxy/stdlib/native/http/index.cxy
@@ -1,0 +1,5 @@
+module _http
+
+@__cc "api.c"
+@__cc "http.c"
+@__cc "llhttp.c"

--- a/src/cxy/stdlib/native/index.cxy
+++ b/src/cxy/stdlib/native/index.cxy
@@ -1,7 +1,0 @@
-module _
-
-@__cc "dns/dns.c"
-@__cc "evloop/ae.c"
-@__cc "memtrace.c"
-@__cc "nos.c"
-

--- a/src/cxy/stdlib/net.cxy
+++ b/src/cxy/stdlib/net.cxy
@@ -1,5 +1,6 @@
 module net
 
+import "unistd.h" as unistd
 import "ifaddrs.h" as ifaddrs
 import "netdb.h" as netdb
 import "arpa/inet.h" as arpa
@@ -15,10 +16,10 @@ else {
 
 import "native/dns/dns.h" as dns
 
-// This will get native sources compiled
-import "./native/index.cxy"
+@__cc "native/dns/dns.c"
+
 // bring in coroutine stuff
-import "./coro.cxy"
+import { State } from "./coro.cxy"
 
 #if (defined MACOS) {
 type sockaddr = socket.sockaddr
@@ -111,7 +112,7 @@ func ntohll(x: u64) : u64 {
 
 // This macro is defined in netinet/in.h, redefining
 // C macros defined with casts cannot be imported
-macro INADDR_ANY 0x00000000:u32
+macro INADDR_ANY 0x00000000 as u32
 
 var cxy_DNS_conf: ^dns.dns_resolv_conf = null;
 var cxy_DNS_hosts: ^dns.dns_hosts = null;
@@ -240,7 +241,7 @@ pub struct Address {
 }
 
 pub func getLocalAddress(name: string, port: u16, mode: IPVersion = IPVersion.Any) {
-    if (name.[0] == '\0':char)
+    if (name.[0] == '\0' as char)
         return Address(port, mode);
 
     var addr = Address(name, port, mode);
@@ -422,4 +423,130 @@ pub async func getRemoteAddress(name: string, port: u16, mode: IPVersion = IPVer
     return addr
 }
 
+pub class Socket {
+    _fd: i32
+    _addr: Address
 
+    @inline func `init`(fd: i32, addr: Address) {
+        _fd = fd
+        _addr = &&addr
+    }
+
+    @inline
+    const func `hash`() => _addr.op__hash()
+
+    @inline
+    const func `!!`() {
+        return !isnull(this) && _fd != -1
+    }
+
+    @inline
+    const func address() => _addr
+
+    @inline
+    const func raw() => _fd
+
+    virtual func receive(buffer: ^void, size: u64, timeout: u64 = 0): u64?
+
+    virtual func sendBuffer(buffer: ^const void, size: u64, timeout: u64 = 0): u64?
+
+    virtual func sendFile(fd: i32, offset: u64, count: u64, timeout: u64 = 0): u64?
+
+    func send[T](data: T, timeout: u64 = 0) {
+        #if (T.isString) {
+            #if (T.isStruct) {
+                return sendBuffer(data.str !: ^void, len!(data), timeout)
+            }
+            else {
+                return sendBuffer(data !: ^void, len!(data), timeout)
+            }
+        }
+        else #if (T.isSlice) {
+            return sendBuffer(data.data, data.count, timeout)
+        }
+        else {
+            error!("type {t} cannot be sent as is, consider using sendBuffer", T)
+        }
+    }
+
+    func close(): void {
+        if (_fd != -1) {
+            unistd.close(_fd)
+            _fd = -1
+        }
+    }
+
+    @inline
+    func `deinit`()  { close() }
+
+    const func `str`(os: &OutputStream) {
+        os << _addr
+    }
+
+    func wait(timeout: u64, state: State) {
+        if (_fd == -1) {
+            errno! = EINVAL!
+            return false
+        }
+
+        if (state == .AE_READABLE) {
+            const rc = fdWaitRead(_fd, timeout);
+            if (rc != State.AE_READABLE) {
+                errno! = ETIMEDOUT!;
+                return false
+            }
+        }
+        else if (state == .AE_WRITABLE) {
+            const rc = fdWaitRead(_fd, timeout);
+            if (rc != State.AE_WRITABLE) {
+                errno! = ETIMEDOUT!;
+                return false
+            }
+        }
+        else {
+            errno! = EINVAL!
+            return false
+        }
+        return true
+    }
+}
+
+pub class SocketOutputStream : OutputStream {
+    - timeout: u64
+    - sock: Socket = null
+
+    func `init`(sock: Socket, timeout: u64 = 0) {
+        this.timeout = timeout
+        this.sock = &&sock
+    }
+
+    func append(data: ^const void, size: u64): u64? {
+        return sock.sendBuffer(data, size, timeout)
+    }
+
+    @inline
+    func sendFile(fd: i32, offset: u64, count: u64, timeout: u64 = 0): u64? {
+        return sock.sendFile(fd, offset, count, timeout)
+    }
+}
+
+pub class BufferedSocketOutputStream : BufferedOutputStream {
+    - timeout: u64
+    - sock: Socket = null
+
+    func `init`(sock: Socket, timeout: u64 = 0) {
+        super()
+        this.timeout = timeout
+        this.sock = &&sock
+    }
+
+    func flush(data: ^const void, size: u64) {
+        sock.sendBuffer(data, size, timeout)
+    }
+
+    func sendFile(fd: i32, offset: u64, count: u64, timeout: u64 = 0): u64? {
+        // flush current buffer
+        this.sync()
+        return sock.sendFile(fd, offset, count, timeout)
+    }
+}

--- a/src/cxy/stdlib/os.cxy
+++ b/src/cxy/stdlib/os.cxy
@@ -3,20 +3,21 @@ module os
 import { State } from "./coro.cxy"
 
 import "errno.h" as errno
-import "stdlib.h" as stdlib
 import "unistd.h" as unistd
 import "sys/wait.h" as syswait
 
 import "native/nos.h" as nos
-import "./native/index.cxy"
+@__cc "native/nos.c"
 
 ##if (defined MACOS) {
 import "sys/_types/_pid_t.h" as pid_t
 import "sys/fcntl.h" as fcntl
 import "copyfile.h" as copyfile
+import "_stdlib.h" as stdlib
 }
 else {
 import "fcntl.h" as fcntl
+import "stdlib.h" as stdlib
 import "sys/types.h" as types
 import "sys/pidfd.h" as pidfd
 import "sys/sendfile.h" as sendfile
@@ -94,7 +95,7 @@ pub enum Seek {
 }
 
 pub struct FileDescriptor {
-    fd = -1:i32;
+    fd = -1 as i32;
     - closeAfter = false;
     func `init`(fd: i32, closeAfter: bool = false) {
         this.fd = fd
@@ -149,7 +150,7 @@ pub func open(
 }
 
 pub struct TempFile {
-    fd = -1:i32;
+    fd = -1 as i32;
     path: String = null;
 
     func `init`(fd: i32, path: String) {
@@ -228,7 +229,7 @@ pub func copy[Src, Dest](dst: &const Dest, src: &const Src): !void {
     }
     else #if (defined UNIX) {
         const size = srcFd.size()
-        var copied = 0:i64
+        var copied = 0 as i64
         while (copied < size) {
             var numWritten = sendfile.sendfile(dstFd.fd, srcFd.fd, ptrof copied, size-copied);
             if (numWritten == -1 || numWritten == 0) {
@@ -352,7 +353,7 @@ pub class FileInputStream: InputStream {
             return &&s
 
         var buf = s.reserve(st.st_size);
-        var nRead = 0:u64;
+        var nRead = 0 as u64;
         while (nRead < st.st_size) {
             var p = ptroff!(buf + nRead)
             var tmp = read(p, st.st_size - nRead)
@@ -436,7 +437,7 @@ pub class FileOutputStream : OutputStream {
     func write(buf: ^const void, size: u64) => append(buf, size)
 
     func writeAsync(buf: ^const void, size: u64, timeout: u64 = 0): !u64 {
-        var numWritten = 0:u64;
+        var numWritten = 0 as u64;
         while (numWritten < size) {
             var p = ptroff!((buf !: ^char) + numWritten)
             var tmp = append(p, size - numWritten)
@@ -522,7 +523,7 @@ pub struct Process {
     }
 
     const func isExited() {
-        var status:i32 = 0;
+        var status = 0 as i32
         const ret = syswait.waitpid(_pid, ptrof status, WNOHANG!);
         if (ret < 0)
             return true
@@ -530,7 +531,7 @@ pub struct Process {
     }
 
     func wait(): !i32 {
-        var status:i32 = 0;
+        var status = 0 as i32;
         const ret = syswait.waitpid(_pid, ptrof status, 0)
         if (ret < 0)
             raise IOError(f"wait for pid ${_pid} failed: ${strerr()}")
@@ -538,7 +539,7 @@ pub struct Process {
         if (WIFEXITED!(status)) {
             return WEXITSTATUS!(status)
         }
-        return -1:i32
+        return -1 as i32
     }
 
     func waitAsync(): !i32 {
@@ -555,7 +556,7 @@ pub struct Process {
             }
 
             defer unistd.close(pidFd)
-            var status:i32 = 0;
+            var status = 0 as i32;
             var ret = syswait.waitpid(_pid, ptrof status, WNOHANG!);
             if (ret < 0)
                 raise IOError(f"wait for pid ${_pid} failed: ${strerr()}")
@@ -569,7 +570,7 @@ pub struct Process {
             if (WIFEXITED!(status)) {
                 return WEXITSTATUS!(status)
             }
-            return -1:i32
+            return -1 as i32
         }
     }
 }

--- a/src/cxy/stdlib/path.cxy
+++ b/src/cxy/stdlib/path.cxy
@@ -1,6 +1,6 @@
 module path
 
-import { Stat, stat, fstat, lstat, IOError } from "stdlib/os.cxy"
+import { Stat, stat, fstat, lstat, getenv, IOError } from "stdlib/os.cxy"
 
 import "unistd.h" as unistd
 import "stdlib.h" as stdlib
@@ -79,7 +79,7 @@ pub struct Path {
 
     @inline
     const func exists() {
-        return unistd.access(path.str() !: ^const char, F_OK!) == 0:i32
+        return unistd.access(path.str() !: ^const char, F_OK!) == 0 as i32
     }
 
     @inline
@@ -105,6 +105,14 @@ pub struct Path {
 
     @inline
     const func size() => path.size()
+
+    const func name() {
+        var sep = path.__str().rfind(DIR_SEPARATOR!)
+        if (sep) {
+            return path.substr(*sep + 1)
+        }
+        return path.__str()
+    }
 }
 
 pub type PathLike = string | __string | String | Path
@@ -150,11 +158,11 @@ pub func cwd(): Path {
 }
 
 pub func homedir() {
-    var dir = stdlib.getenv("HOME" !: ^const char);
-    if (dir ==  null) {
-        dir = pwd.getpwuid(unistd.getuid()).pw_dir
+    var dir = getenv("HOME") catch "".s
+    if (dir.empty()) {
+        dir = __string(pwd.getpwuid(unistd.getuid()).pw_dir !: string)
     }
-    return Path(dir !: string)
+    return Path(dir)
 }
 
 pub func expand(path: PathLike) {
@@ -168,7 +176,7 @@ pub func expand(path: PathLike) {
         return &&ppath
 
     var i = 0;
-    while (spath.[i] == '~':char || spath.[i] == '/':char) i++;
+    while (spath.[i] == '~' as char || spath.[i] == '/' as char) i++;
     spath = spath.substr(i)
     if (spath.empty())
         return home
@@ -195,7 +203,7 @@ pub func exists(path: PathLike) {
     if (spath.empty())
         return false
 
-    return withNullTermination[bool](&spath, (p: ^const char) => unistd.access(p, F_OK!) == 0:i32)
+    return withNullTermination[bool](&spath, (p: ^const char) => unistd.access(p, F_OK!) == 0 as i32)
 }
 
 pub func isfile(path: PathLike) {
@@ -373,4 +381,19 @@ pub func remove(path: PathLike, recursive: bool = false): !void {
         if (status != 0)
             raise IOError(f"deleting file '${spath}' failed: ${strerr()}")
     }
+}
+
+pub func getFileSize(path: PathLike): !u64 {
+    var spath = cast[__string](&path);
+    var result = withNullTermination[bool|u64](&spath, (p: ^const char): bool|u64 => {
+        var s = Stat{};
+        if (stat(p !: string, ptrof s) != 0) {
+            return false
+        }
+        return <u64>s.st_size
+    })
+
+    if (result is #bool)
+        raise IOError(f"Getting file '${path}' size failed: ${strerr()}")
+    return result as u64
 }

--- a/src/cxy/stdlib/ssl.cxy
+++ b/src/cxy/stdlib/ssl.cxy
@@ -1,0 +1,260 @@
+module ssl
+
+import { Socket, Address } from "./net.cxy"
+import { State } from "./coro.cxy"
+
+import "./log.cxy"
+
+import "unistd.h" as unistd
+import "sys/mman.h" as vmem
+import "openssl/bio.h" as BIO
+import "openssl/ssl.h" as SSL
+import "openssl/err.h" as ERR
+import "openssl/crypto.h" as CRYPTO
+import "openssl/types.h" as TYPES
+
+@__cc:clib "ssl"
+@__cc:clib "crypto"
+
+@thread
+var initSslOnce = false;
+
+macro ERR_SYSTEM_FLAG                =(INT_MAX! + 1)
+macro ERR_SYSTEM_MASK                =(INT_MAX!)
+macro ERR_SYSTEM_ERROR(errcode)      =(((errcode!) & ERR_SYSTEM_FLAG!) != 0)
+macro SSL_load_error_strings()       =(
+    SSL.OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS! | OPENSSL_INIT_LOAD_CRYPTO_STRINGS!, null)
+)
+macro SSL_library_init()             =( SSL.OPENSSL_init_ssl(0, null) )
+macro OpenSSL_add_all_algorithms     =(
+     CRYPTO.OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS! | OPENSSL_INIT_ADD_ALL_DIGESTS!, null)
+)
+
+macro BIO_get_ssl(b, sslp)     =(
+    BIO.BIO_ctrl(b!, BIO_C_GET_SSL!, 0,(sslp! !: ^char))
+)
+
+macro BIO_flush(b)             =(BIO.BIO_ctrl(b!, BIO_CTRL_FLUSH!,0, null))
+
+macro SSL_set_mode(ssl, op)    =(
+    SSL.SSL_ctrl((ssl!), SSL_CTRL_MODE! ,(op!), null)
+)
+
+macro BIO_should_retry(a)      =(BIO.BIO_test_flags(a!, BIO_FLAGS_SHOULD_RETRY!))
+macro BIO_should_read(a)       =(BIO.BIO_test_flags(a!, BIO_FLAGS_READ!))
+macro BIO_should_write(a)      =(BIO.BIO_test_flags(a!, BIO_FLAGS_WRITE!))
+macro BIO_do_handshake(b)      =(BIO.BIO_ctrl(b!, BIO_C_DO_STATE_MACHINE!, 0, null))
+
+@inline
+func ERR_GET_LIB(code: u64) {
+    if (ERR_SYSTEM_ERROR!(code))
+        return <u64>ERR_LIB_SYS!
+    return (code >> ERR_LIB_OFFSET!) & ERR_LIB_MASK!
+}
+
+@thread
+var sslClientCtx = initialize();
+
+const LOG_TAG = "SSL_PROTO";
+
+func initialize() {
+    assert!(!initSslOnce)
+    initSslOnce = true
+
+    SSL_load_error_strings!()
+    SSL_library_init!()
+    OpenSSL_add_all_algorithms!()
+    var ctx = SSL.SSL_CTX_new(SSL.TLS_client_method());
+    assert!(ctx != null)
+    return ctx
+}
+
+pub exception SslError(msg: String) =>
+    msg != null? msg.str() : ""
+
+@inline
+func getSslError(): string {
+    var code = ERR.ERR_get_error()
+    if (code != 0)
+        return ERR.ERR_error_string(code, null) !: string
+    return null
+}
+
+pub class SslSocket: Socket {
+    - bio: ^TYPES.bio_st = null;
+
+    - func bioFlush(ssl: ^TYPES.ssl_st, timeout: u64) {
+        while (true) {
+            var rc = BIO_flush!(bio)
+            if (rc >= 0)
+                return true
+
+            var err = SSL.SSL_get_error(ssl, <i32>rc)
+            if (err != SSL_ERROR_WANT_WRITE!) {
+                errno! = ECONNRESET!
+                TRC!( "BIO_get_ssl failed: " << getSslError() )
+                return false
+            }
+
+            if (!wait(timeout, State.AE_WRITABLE)) {
+                TRC!( "Waiting for socket to be writable failed during flush")
+                return false
+            }
+        }
+    }
+
+    func `init`(fd: i32, addr: Address, bio: ^TYPES.bio_st) {
+        super(fd, &&addr)
+        this.bio = bio
+    }
+
+    @static
+    func create(fd: i32, addr: Address, ctx: ^TYPES.ssl_ctx_st = sslClientCtx): !This {
+        var ssl: ^TYPES.ssl_st = null
+        var bio = SSL.BIO_new_ssl(ctx, (ctx == sslClientCtx)? 1 : 0)
+        if (bio == null) {
+            unistd.close(fd)
+            raise SslError(f"BIO_new_ssl failed: ${getSslError()}")
+        }
+
+        BIO_get_ssl!(bio, ptrof ssl)
+        if (ssl == null) {
+            BIO.BIO_free(bio)
+            unistd.close(fd)
+            raise SslError(f"BIO_get_ssl failed: ${getSslError()}")
+        }
+
+        SSL_set_mode!(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE!|SSL_MODE_AUTO_RETRY!)
+        var cbio = BIO.BIO_new_socket(fd, BIO_NOCLOSE!)
+        if (cbio == null) {
+            BIO.BIO_free(bio)
+            unistd.close(fd)
+            raise SslError( f"BIO_new_socket failed: ${getSslError()}")
+        }
+
+        BIO.BIO_push(bio, cbio)
+
+        while (true) {
+            var rc = BIO_do_handshake!(bio);
+            if (rc <= 0) {
+                var err = SSL.SSL_get_error(ssl, <i32>rc);
+                if (err == SSL_ERROR_WANT_WRITE!) {
+                    if (fdWaitWrite(fd, 0) == State.AE_WRITABLE)
+                        continue
+                }
+                else if (err == SSL_ERROR_WANT_READ!) {
+                    if (fdWaitRead(fd, 0) == State.AE_READABLE)
+                        continue
+                }
+
+                BIO.BIO_free_all(bio)
+                unistd.close(fd)
+                raise SslError( f"BIO_new_socket failed(${err}): ${getSslError()}")
+            }
+            TRC3!("SSL handshake done")
+            break
+        }
+        return This(fd, &&addr, bio)
+    }
+
+    func sendBuffer(buf: ^const void, size: u64, timeout: u64 = 0): u64? {
+        var ssl: ^TYPES.ssl_st = null;
+        BIO_get_ssl!(bio, ptrof ssl)
+        if (ssl == null) {
+            ERR!( "BIO_get_ssl failed: " << getSslError())
+            return null
+        }
+
+        if (buf == null) {
+            if (!bioFlush(ssl, timeout))
+                return null
+        }
+
+        var written = 0 as u64
+        var p = buf !: ^u8
+        while (written < size) {
+            var rc = BIO.BIO_write(bio, ptroff!(p + written), <i32>(size - written))
+            if (rc <= 0) {
+                var err = SSL.SSL_get_error(ssl, <i32>rc)
+                if (err != SSL_ERROR_WANT_WRITE!) {
+                    errno! = ECONNRESET!
+                    TRC!( "BIO_get_ssl failed: " << getSslError())
+                    return null
+                }
+
+                if (!wait(timeout, State.AE_WRITABLE)) {
+                    TRC!( "Waiting for socket to be writable failed")
+                    return null
+                }
+                continue
+            }
+
+            written += rc
+        }
+        return written
+    }
+
+    func sendFile(fd: i32, offset: u64, count: u64, timeout: u64 = 0): u64? {
+        // Sendfile not supported for SSL
+        const len = ((count + (SysConfPageSize - 1)) & ~(SysConfPageSize - 1)) + SysConfPageSize;
+        var ptr  = vmem.mmap(null,
+                             len,
+                             PROT_READ!,
+                             MAP_PRIVATE!,
+                             fd,
+                             <i64>offset)
+        if (ptr == ((-1 as u64) !: ^void)) {
+            TRC!("mmap(" << fd << ") failed: " << strerr())
+            return null
+        }
+
+        var ret = sendBuffer(ptr, count, timeout);
+        vmem.munmap(ptr, len)
+        return ret
+    }
+
+    func receive(buf: ^void, size: u64, timeout: u64 = 0): u64? {
+        var ssl: ^TYPES.ssl_st = null;
+        BIO_get_ssl!(bio, ptrof ssl)
+        if (ssl == null) {
+            ERR!( "BIO_get_ssl failed: " << getSslError())
+            return null
+        }
+
+        var nRead = 0 as u64
+        var p = buf !: ^u8;
+        while (nRead < size) {
+            var rc = BIO.BIO_read(bio, ptroff!(p + nRead), <i32>(size - nRead));
+            if (rc < 0) {
+                var err = SSL.SSL_get_error(ssl, <i32>rc);
+                if (err != SSL_ERROR_WANT_READ!) {
+                    ERR!( "BIO_get_ssl failed: " << getSslError())
+                    errno! = ECONNRESET!
+                    return null
+                }
+
+                if (nRead > 0)
+                    return nRead // Return what we have read so far
+
+                if (!wait(timeout, State.AE_READABLE)) {
+                    TRC!( f"Waiting for socket to be readable timed out")
+                    return null
+                }
+                continue
+            }
+            else if (rc == 0)
+                return nRead
+            nRead += rc
+        }
+
+        return nRead
+    }
+
+    func `deinit`() {
+        if (bio != null) {
+            SSL.BIO_ssl_shutdown(bio)
+            BIO.BIO_free_all(bio);
+            bio = null
+        }
+    }
+}

--- a/src/cxy/stdlib/tcp.cxy
+++ b/src/cxy/stdlib/tcp.cxy
@@ -1,6 +1,6 @@
 module tcp
 
-import { Address } from "./net.cxy"
+import { Address, Socket } from "./net.cxy"
 import { State } from "./coro.cxy"
 
 import "sys/socket.h" as socket
@@ -31,7 +31,7 @@ else {
     @inline
     func Socket_sendfile(outFd: i32, inFd: i32, off: ^u64, count: u64) {
         var size = <i64> count;
-        var status = socket.sendfile(inFd, outFd, <i64>*off, ptrof size, null, 0:i32)
+        var status = socket.sendfile(inFd, outFd, <i64>*off, ptrof size, null, 0 as i32)
         if (status == 0)
             *off = *off + size
         return status
@@ -49,47 +49,24 @@ func configureSocket(fd: i32)  {
     opt = 1;
     rc = socket.setsockopt(fd, SOL_SOCKET!, SO_REUSEADDR!, ptrof opt, <u32>sizeof!(opt));
     assert!(rc == 0);
-
-//#if (defined MACOS) {
-//    opt = 1;
-//    rc = socket.setsockopt(fd, SOL_SOCKET!, SO_NOSIGPIPE!, ptrof opt, <u32>sizeof!(opt));
-//    const err = errno!;
-//    assert!(rc == 0 && err != EINVAL!);
-//}
 }
 
-pub class TcpSocket {
-    - addr: Address
-    - fd: i32
-
+pub class TcpSocket: Socket {
     func `init`(fd: i32, addr: Address) {
-        this.fd = fd
-        this.addr = addr
-        configureSocket(this.fd)
+        super(fd, &&addr)
     }
 
     func `init`() {
-        fd = -1
+        super(-1 as i32, Address())
     }
-
-    @inline
-    const func `hash`() => addr.op__hash()
-
-    @inline
-    const func `!!`() {
-        return !isnull(this) && fd != -1
-    }
-
-    @inline
-    const func address() => addr
 
     func receive(buffer: ^void, size: u64, timeout: u64 = 0): u64? {
         var remaining = size;
         var data = buffer !: ^char;
         var total: u64 = 0;
 
-        while (fd != -1 && remaining > 0) {
-            var sz = socket.recv(fd, ptrof data.[total], remaining, 0);
+        while (super._fd != -1 && remaining > 0) {
+            var sz = socket.recv(super._fd, ptrof data.[total], remaining, 0);
             if (sz == 0) {
                 if (total > 0)
                     return total
@@ -108,11 +85,8 @@ pub class TcpSocket {
                 if (total > 0)
                     return total
 
-                var rc = fdWaitRead(fd, timeout);
-                if (rc != State.AE_READABLE) {
-                    errno! = ETIMEDOUT!;
+                if (!wait(timeout, State.AE_READABLE))
                     return null
-                }
 
                 continue
             }
@@ -128,8 +102,8 @@ pub class TcpSocket {
         var data = buffer !: ^const char;
         var remaining = size;
         var total: u64 = 0;
-        while (fd != -1 && remaining > 0) {
-            var sz = socket.send(fd, ptrof data.[total], remaining, 0);
+        while (super._fd != -1 && remaining > 0) {
+            var sz = socket.send(super._fd, ptrof data.[total], remaining, 0);
             if (sz == -1 || sz == 0) {
                 if(errno! == EPIPE!) {
                     errno! = ECONNRESET!
@@ -140,11 +114,9 @@ pub class TcpSocket {
                 if (errno! != EAGAIN! && errno! != EWOULDBLOCK!)
                     return null
 
-                var rc = fdWaitWrite(fd, timeout);
-                if (rc != State.AE_WRITABLE) {
-                    errno! = ETIMEDOUT!
+                if (!wait(timeout, State.AE_WRITABLE))
                     return null
-                }
+
                 continue
             }
 
@@ -159,7 +131,7 @@ pub class TcpSocket {
         var toffset = offset + count
         var remaining = count
         while (toffset > offset) {
-            var sz = Socket_sendfile(this.fd, fd, ptrof offset, remaining)
+            var sz = Socket_sendfile(super._fd, fd, ptrof offset, remaining)
             if (sz == -1 || sz == 0) {
                 if (errno!  == EPIPE!) {
                     errno! = ECONNRESET!
@@ -170,84 +142,14 @@ pub class TcpSocket {
                 if (errno! != EAGAIN! && errno! != EWOULDBLOCK!)
                     return null
 
-                var rc = fdWaitWrite(fd, timeout);
-                if (rc != State.AE_WRITABLE) {
-                    errno! = ETIMEDOUT!
+                if (!wait(timeout, State.AE_WRITABLE))
                     return null
-                }
                 continue
             }
             remaining -= sz
         }
         errno! = 0
         return count
-    }
-
-    func send[T](data: T, timeout: u64 = 0) {
-        #if (T.isString) {
-            #if (T.isStruct) {
-                return sendBuffer(data.str !: ^void, len!(data), timeout)
-            }
-            else {
-                return sendBuffer(data !: ^void, len!(data), timeout)
-            }
-        }
-        else #if (T.isSlice) {
-            return sendBuffer(data.data, data.count, timeout)
-        }
-        else {
-            error!("type {t} cannot be sent as is, consider using sendBuffer", T)
-        }
-    }
-
-    func close(): void {
-        if (fd != -1) {
-            unistd.close(fd)
-            fd = -1
-        }
-    }
-
-    @inline
-    func `deinit`()  { close() }
-
-    const func `str`(os: &OutputStream) {
-        os << addr
-    }
-}
-
-class SocketOutputStream : OutputStream {
-    - sock: TcpSocket
-    - timeout: u64
-
-    func `init`(sock: TcpSocket, timeout: u64 = 0) {
-        this.sock = sock
-        this.timeout = timeout
-    }
-
-    func append(data: ^const void, size: u64): u64? {
-        return sock.sendBuffer(data, size, timeout)
-    }
-}
-
-pub class BufferedSocketOutputStream : BufferedOutputStream {
-    - sock: TcpSocket
-    - timeout: u64
-
-    func `init`(sock: TcpSocket, timeout: u64 = 0) {
-        super()
-        this.sock = &&sock
-        this.timeout = timeout
-    }
-
-    func flush(data: ^const void, size: u64) {
-        sock.sendBuffer(data, size, timeout)
-    }
-
-    @inline
-    func sendFile(fd: i32, offset: u64, count: u64, timeout: u64 = 0): u64? {
-        // flush current buffer
-        this.sync()
-        return sock.sendFile(fd, offset, count, timeout)
     }
 }
 
@@ -300,6 +202,7 @@ pub class TcpListener {
             var len = <u32> sizeof!(addr);
             var accepted = socket.accept(fd, addr.nativeAddr(), ptrof len);
             if (accepted >= 0) {
+                configureSocket(this.fd)
                 return TcpSocket(accepted, addr)
             }
 
@@ -329,25 +232,25 @@ pub class TcpListener {
     func `deinit`() { close(); }
 }
 
-pub async func tcpConnect(addr: Address, @unused deadline: i64 = 0): TcpSocket {
+exception TcpError(msg: String) => msg == null? "": msg.str()
+
+pub func tcpConnect(addr: Address, timeout: u64 = 0): !i32 {
     /* Open a socket. */
     var fd = socket.socket(addr.family(), <i32>SOCK_STREAM!, 0);
     if (fd == -1)
-        return null
-
-    var sock = TcpSocket(fd, addr);
+        raise TcpError(f"socket.socket(${addr}) failed: ${strerr()}")
 
     /* Connect to the remote endpoint. */
     var rc = socket.connect(fd, addr.nativeAddr(), <i32>addr.len());
     if (rc != 0) {
         assert!(rc == -1)
         if (errno! != EINPROGRESS!)
-            return null
+            raise TcpError(f"socket.connect(${addr}) failed: ${strerr()}")
 
-        rc = fdWaitRead(fd)
-        if (rc == 0) {
+        rc = fdWaitWrite(fd, timeout)
+        if (rc != State.AE_WRITABLE) {
             errno! = ETIMEDOUT!
-            return null
+            raise TcpError(f"Waiting for socket(${addr}) to be writable failed")
         }
 
         var err: i32 = 0;
@@ -357,16 +260,17 @@ pub async func tcpConnect(addr: Address, @unused deadline: i64 = 0): TcpSocket {
             err = errno!
             unistd.close(fd)
             errno! = err
-            return null
+            raise TcpError(f"socket.getsockopt(${addr}) failed: ${strerr()}")
         }
 
         if (err != 0) {
             unistd.close(fd)
             errno! = err
-            return null
+            raise TcpError(f"socket(${addr}) error: ${strerr()}")
         }
     }
 
     errno! = 0
-    return sock
+    configureSocket(fd)
+    return fd
 }

--- a/src/cxy/stdlib/thread.cxy
+++ b/src/cxy/stdlib/thread.cxy
@@ -10,12 +10,12 @@ pub exception ThreadError(msg: String) => msg == null? "" : msg.str()
 macro DEFAULT_TID null
 }
 else #if (defined UNIX) {
-macro DEFAULT_TID 0:u64
+macro DEFAULT_TID 0 as u64
 }
 
 struct Handle {
     - hdl: tinyThread.thrd_t = DEFAULT_TID!;
-    - _id = 0:u64;
+    - _id = 0 as u64;
 
     func `init`(hdl: tinyThread.thrd_t) {
         this.hdl = hdl

--- a/src/cxy/stdlib/time.cxy
+++ b/src/cxy/stdlib/time.cxy
@@ -42,7 +42,7 @@ pub struct Time {
     }
 
     const func format(fmt: string, os: &OutputStream) {
-        if (fmt.[0] != '\0':char) {
+        if (fmt.[0] != '\0' as char) {
             var buf: [char, 512] = [];
             var sz = ctime.strftime(buf, 512, fmt !: ^const char, ptrof _tm);
             os.append(buf, sz)

--- a/src/cxy/stdlib/trie.cxy
+++ b/src/cxy/stdlib/trie.cxy
@@ -7,7 +7,7 @@ struct TrieNode[T] {
     - tag: char;
     - data: T?;
 
-    func `init`(c: char = '\0':char) {
+    func `init`(c: char =  '\0'as char) {
         tag = c
         data = null
         children = HashMap[wchar, ^This]();


### PR DESCRIPTION
- Added SSL support using openssl
- Add an http client `fetch`
- Add redirection syntax which types can implement to redirect calls

```c

/* Fetch API */
var resp = fetch("https://example.org")
if (resp.ok())
     println(resp.body())

/* Redirection */
struct User {
    name: string
}

struct UserContainer {
    user: User
    func `&.`() => &user
}


var uc = UserContainer{};
println(uc&.name)
```